### PR TITLE
Disable relocation addend for all targets.

### DIFF
--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -126,7 +126,9 @@ class ELFObjectWriter : public MCObjectWriter {
     // TargetObjectWriter wrappers.
     bool is64Bit() const { return TargetObjectWriter->is64Bit(); }
     bool hasRelocationAddend() const {
-      return TargetObjectWriter->hasRelocationAddend();
+      // Keystone doesn't want relocation addends.
+      /* return TargetObjectWriter->hasRelocationAddend(); */
+      return false;
     }
     unsigned getRelocType(MCContext &Ctx, const MCValue &Target,
                           const MCFixup &Fixup, bool IsPCRel) const {


### PR DESCRIPTION
Since Keystone will not be generating actual ELF files, relocation addends prevent symbol addresses from being inlined in the output. This patch disables relocation added for all targets.

Fixes #34.
