### PR TITLE
Add ks_asm() Address to symbol offset.

### DIFF
--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -220,6 +220,8 @@ namespace llvm {
 
     bool HadError;
 
+    uint64_t BaseAddress;
+
     MCSymbol *createSymbolImpl(const StringMapEntry<bool> *Name,
                                bool CanBeUnnamed);
     MCSymbol *createSymbol(StringRef Name, bool AlwaysAddSuffix,
@@ -231,7 +233,8 @@ namespace llvm {
   public:
     explicit MCContext(const MCAsmInfo *MAI, const MCRegisterInfo *MRI,
                        const MCObjectFileInfo *MOFI,
-                       const SourceMgr *Mgr = nullptr, bool DoAutoReset = true);
+                       const SourceMgr *Mgr = nullptr, bool DoAutoReset = true,
+                       uint64_t BaseAddress = 0);
     ~MCContext();
 
     const SourceMgr *getSourceManager() const { return SrcMgr; }
@@ -244,6 +247,8 @@ namespace llvm {
 
     void setAllowTemporaryLabels(bool Value) { AllowTemporaryLabels = Value; }
     void setUseNamesOnTempLabels(bool Value) { UseNamesOnTempLabels = Value; }
+
+    uint64_t getBaseAddress() { return BaseAddress; }
 
     /// \name Module Lifetime Management
     /// @{

--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -504,7 +504,7 @@ int ks_asm(ks_engine *ks,
     *insn = NULL;
     *insn_size = 0;
 
-    Ctx = new MCContext(ks->MAI, ks->MRI, &ks->MOFI, &ks->SrcMgr);
+    Ctx = new MCContext(ks->MAI, ks->MRI, &ks->MOFI, &ks->SrcMgr, true, address);
     ks->MOFI.InitMCObjectFileInfo(Triple(ks->TripleName), *Ctx);
     CE = ks->TheTarget->createMCCodeEmitter(*ks->MCII, *ks->MRI, *Ctx);
 

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -303,7 +303,7 @@ void MCAsmLayout::layoutFragment(MCFragment *F) {
   if (Prev)
     F->Offset = Prev->Offset + getAssembler().computeFragmentSize(*this, *Prev);
   else
-    F->Offset = 0;
+    F->Offset = getAssembler().getContext().getBaseAddress();
   LastValidFragment[F->getParent()] = F;
 
   // If bundling is enabled and this fragment has instructions in it, it has to

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -36,13 +36,13 @@ using namespace llvm;
 
 MCContext::MCContext(const MCAsmInfo *mai, const MCRegisterInfo *mri,
                      const MCObjectFileInfo *mofi, const SourceMgr *mgr,
-                     bool DoAutoReset)
+                     bool DoAutoReset, uint64_t BaseAddr)
     : SrcMgr(mgr), MAI(mai), MRI(mri), MOFI(mofi), Allocator(),
       Symbols(Allocator), UsedNames(Allocator),
       CurrentDwarfLoc(0, 0, 0, DWARF2_FLAG_IS_STMT, 0, 0), DwarfLocSeen(false),
       GenDwarfForAssembly(false), GenDwarfFileNumber(0), DwarfVersion(4),
       AllowTemporaryLabels(true), DwarfCompileUnitID(0),
-      AutoReset(DoAutoReset), HadError(false) {
+      AutoReset(DoAutoReset), HadError(false), BaseAddress(BaseAddr) {
 
   std::error_code EC = llvm::sys::fs::current_path(CompilationDir);
   if (EC)


### PR DESCRIPTION
This passes the Address provided to ks_asm down to MCAssembler::layout where it's added to the fixed up value and applied to the encoded output.

Not sure what the impact is on other architectures and whether it's the right approach, but it seems to work for x86/x86_64.
