### PR TITLE
ignore all directories with the build prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 *.github.io
 _*.diff
 
-build
+build*/
 docs/sample/sample
 _sample*.txt
 tmp


### PR DESCRIPTION
I think this is beneficial to the build process because I usually create directories like `build64` `build-arm` and `build-mingw` this will ignore all these in one hit. 
