### PR TITLE
Don't output the symbol's name instead of its value.

### DIFF
--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -130,14 +130,15 @@ void MCObjectStreamer::EmitValueImpl(const MCExpr *Value, unsigned Size,
   MCDataFragment *DF = getOrCreateDataFragment();
   flushPendingLabels(DF, DF->getContents().size());
 
-  if (Value->getKind() == MCExpr::SymbolRef) {
-      // Keystone: record data in the same section
-      const MCSymbolRefExpr &SRE = cast<MCSymbolRefExpr>(*Value);
-      const StringRef Sym = SRE.getSymbol().getName();
-      DF->getContents().append(Sym.begin(), Sym.end());
-
-      return;
-  }
+  // This makes the symbol's name (label) end up literally in the output stream
+  //if (Value->getKind() == MCExpr::SymbolRef) {
+  //    // Keystone: record data in the same section
+  //    const MCSymbolRefExpr &SRE = cast<MCSymbolRefExpr>(*Value);
+  //    const StringRef Sym = SRE.getSymbol().getName();
+  //    DF->getContents().append(Sym.begin(), Sym.end());
+  //
+  //    return;
+  //}
 
   //MCCVLineEntry::Make(this);
   //MCDwarfLineEntry::Make(this, getCurrentSection().first);


### PR DESCRIPTION
Besides fixing `ldr Rd,=label` on ARM, this also fixes defining addresses
of symbols as literals (`.int label1`) on all platforms.

Fixes #46 
