### PR TITLE
Don't store StringRef to StringRef::lower().

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -4732,7 +4732,7 @@ bool AsmParser::parseNasmDirectiveBits()
 
 bool AsmParser::parseNasmDirectiveDefault()
 {
-  StringRef flag = parseStringToEndOfStatement().lower();
+  std::string flag = parseStringToEndOfStatement().lower();
   if (flag == "rel") {
     setNasmDefaultRel(true);
     return false;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -1282,7 +1282,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End)
   // nasm tokens rel / abs are only valid at the beginning of the expression.
   if (KsSyntax == KS_OPT_SYNTAX_NASM) {
     while (getLexer().getKind() == AsmToken::Identifier) {
-      StringRef Identifier = Tok.getString().lower();
+      std::string Identifier = Tok.getString().lower();
       if (Identifier == "rel") {
         SM.onRel();
         consumeToken();
@@ -1826,7 +1826,7 @@ std::unique_ptr<X86Operand> X86AsmParser::ParseIntelOperand(StringRef Mnem)
 
   // Offset, length, type and size operators.
   if (isParsingInlineAsm()) {
-    StringRef AsmTokStr = Tok.getString().lower();
+    std::string AsmTokStr = Tok.getString().lower();
     if (AsmTokStr == "offset")
       return ParseIntelOffsetOfOperator();
     if (AsmTokStr == "length")


### PR DESCRIPTION
`StringRef::lower()` returns a new string which should be stored and not just referenced. Valgrind shows invalid reads if you just store the ref.

```
==7032== Invalid read of size 1
==7032==    at 0x4C30C09: __memcmp_sse4_1 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7032==    by 0x512BFED: (anonymous namespace)::X86AsmParser::ParseIntelExpression((anonymous namespace)::X86AsmParser::IntelExprStateMachine&, llvm::SMLoc&) [clone .constprop.201] (in /usr/local/lib/libkeystone.so.1)
...
==7032==  Address 0x6354888 is 24 bytes inside a block of size 28 free'd
==7032==    at 0x4C2C2BC: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7032==    by 0x512CBC7: (anonymous namespace)::X86AsmParser::ParseIntelExpression((anonymous namespace)::X86AsmParser::IntelExprStateMachine&, llvm::SMLoc&) [clone .constprop.201] (in /usr/local/lib/libkeystone.so.1)
```
