### PR TITLE
Fix memory leaks.

### DIFF
--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -35,8 +35,6 @@ MCObjectStreamer::MCObjectStreamer(MCContext &Context, MCAsmBackend &TAB,
       EmitEHFrame(true), EmitDebugFrame(false) {}
 
 MCObjectStreamer::~MCObjectStreamer() {
-  delete &Assembler->getBackend();
-  delete &Assembler->getEmitter();
   delete &Assembler->getWriter();
   delete Assembler;
 }


### PR DESCRIPTION
Uses new / delete like in mrexodia's patch, deletes things allocated
in ks_asm properly, clean up properly in ks_close. Removed 2 deletes
from the MCObjectStreamer destructor that we re-use in a second run
of ks_asm on the same keystone instance.

Valgrind on Ubuntu 14.04 shows no invalid reads and no memory leaks
in keystone after running the regression tests.

Should fix #16 

@aquynh Could you check if this still crashes in the Ubuntu environment that made you revert the earlier patches?
