### PR TITLE
added regression test for the issue discovered in #9

### DIFF
--- a/suite/regress/x86_address.py
+++ b/suite/regress/x86_address.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+# Test if addr == 0 and addr != 0 produces the same results on a NOP.
+
+# Github issue: #9
+# Author: Duncan (mrexodia)
+
+from keystone import *
+
+import regress
+
+class TestX86Intel(regress.RegressTest):
+    def runTest(self):
+        # Initialize Keystone engine
+        ks = Ks(KS_ARCH_X86, KS_MODE_32)
+        # Assemble with zero addr
+        encoding1, count1 = ks.asm("nop", 0)
+        # Assemble with non-zero addr
+        encoding2, count2 = ks.asm("nop", 0x9123FFE1)
+        # Assert the result
+        self.assertEqual(encoding1, [ 0x90 ])
+        self.assertEqual(count1, 1)
+        self.assertEqual(encoding1, encoding2)
+        self.assertEqual(count1, count2)
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
```
======================================================================
FAIL: runTest (__main__.TestX86Intel)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\xxx\x86_address.py", line 23, in runTest
    self.assertEqual(encoding1, encoding2)
AssertionError: Lists differ: [144] != [15, 31, 0, 144]

First differing element 0:
144
15

Second list contains 3 additional elements.
First extra element 1:
31

- [144]
+ [15, 31, 0, 144]

----------------------------------------------------------------------
```
