### PR TITLE
Add 13 assertion failure crashers.

### DIFF
--- a/suite/regress/c-crashers/Makefile
+++ b/suite/regress/c-crashers/Makefile
@@ -1,0 +1,6 @@
+LIBNAME = keystone
+CFLAGS = -Wall -l$(LIBNAME)
+PROGS = $(patsubst %.c, %, $(wildcard crash-??-*.c))
+all: $(PROGS)
+clean:
+	$(RM) $(PROGS)

--- a/suite/regress/c-crashers/crash-01-empty-tombstone-value-shouldnt-be-inserted-into-map.c
+++ b/suite/regress/c-crashers/crash-01-empty-tombstone-value-shouldnt-be-inserted-into-map.c
@@ -1,0 +1,19 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_ARM, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'b', '&', ';', 'b', ' ', '0', 'b', '&', 'R', 'b',
+    ' ', 0x10, 'b', 0x09, '0', 'b', '&', ';', 'b', ' ',
+    '0', '7', '7', '7', '7', '7', '7', '7', '7', '7',
+    '7', '7', '7', '7', '7', '7', '7', 'b', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+  return 0;
+}

--- a/suite/regress/c-crashers/crash-02-index-lt-size-failed.c
+++ b/suite/regress/c-crashers/crash-02-index-lt-size-failed.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_HEXAGON, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    '.', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-03-invalid-index.c
+++ b/suite/regress/c-crashers/crash-03-invalid-index.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_ARM, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    '"', '"', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-04-readcount-not-equal-to-one.c
+++ b/suite/regress/c-crashers/crash-04-readcount-not-equal-to-one.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_HEXAGON, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'B', ':', '/', '/', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-05-normal-symbols-cannot-be-unnamed.c
+++ b/suite/regress/c-crashers/crash-05-normal-symbols-cannot-be-unnamed.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'D', '"', '"', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-06-exponent-has-no-digits-in-apfloat-line-126.c
+++ b/suite/regress/c-crashers/crash-06-exponent-has-no-digits-in-apfloat-line-126.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    '}', '8', 'e', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-07-exponent-has-no-digits-in-apfloat-line-131.c
+++ b/suite/regress/c-crashers/crash-07-exponent-has-no-digits-in-apfloat-line-131.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'T', 'T', 'T', 'T', 'T', ' ', '.', '0', '8', 'e',
+    '+', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-08-invalid-character-in-exponent-absexponent-case.c
+++ b/suite/regress/c-crashers/crash-08-invalid-character-in-exponent-absexponent-case.c
@@ -1,0 +1,15 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'J', '-', '9', 'e', 'e', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-09-invalid-character-in-exponent-value-case.c
+++ b/suite/regress/c-crashers/crash-09-invalid-character-in-exponent-value-case.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_HEXAGON, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'R', '#', '5', '5', '5', 'D', '#', '5', '5', 'e',
+    '5', 'E', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-10-stringref-cannot-be-built-from-a-null-argument.c
+++ b/suite/regress/c-crashers/crash-10-stringref-cannot-be-built-from-a-null-argument.c
@@ -1,0 +1,12 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, 0, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-11-elfobjectwriter-should-not-have-constructed-this.c
+++ b/suite/regress/c-crashers/crash-11-elfobjectwriter-should-not-have-constructed-this.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'J', '-', '9', '-', 'T', 'I', '@', 'h', '-', '-',
+    '9', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-12-cannot-set-a-variable-that-has-already-been-used.c
+++ b/suite/regress/c-crashers/crash-12-cannot-set-a-variable-that-has-already-been-used.c
@@ -1,0 +1,18 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'A', 'A', '=', 'F', '/', 'A', 0x0a, 'F', '/', 'A',
+    0x0a, 'A', 'A', '=', 'F', '/', 'a', 0x0a, 'A', '=',
+    '9', '/', '7', 0x0a, 'A', 'A', '=', 'F', '/', 'a',
+    0x0a, 'A', '=', 'F', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-13-hexagon-mc-code-emitter-mk-is-not-equal-to-symbolref.c
+++ b/suite/regress/c-crashers/crash-13-hexagon-mc-code-emitter-mk-is-not-equal-to-symbolref.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_HEXAGON, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'R', '1', '9', '=', 0xff, '#', 'R', '+', 'R', '1',
+    'o', 'Q', '^', '+', 'R', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+  }
+  ks_close(ks);
+}


### PR DESCRIPTION
Add 13 assertion failure crashers:

```
$ ./crash-01-empty-tombstone-value-shouldnt-be-inserted-into-map
/path/to/llvm/include/llvm/ADT/DenseMap.h:484: bool llvm::DenseMapBase<DerivedT, KeyT, ValueT, KeyInfoT, BucketT>::LookupBucketFor(const LookupKeyT&, const BucketT*&) const [with LookupKeyT = unsigned int; DerivedT = llvm::DenseMap<unsigned int, llvm::MCLabel*>; KeyT = unsigned int; ValueT = llvm::MCLabel*; KeyInfoT = llvm::DenseMapInfo<unsigned int>; BucketT = llvm::detail::DenseMapPair<unsigned int, llvm::MCLabel*>]: Assertion `!KeyInfoT::isEqual(Val, EmptyKey) && !KeyInfoT::isEqual(Val, TombstoneKey) && "Empty/Tombstone value shouldn't be inserted into map!"' failed.

$ ./crash-02-index-lt-size-failed
/path/to/llvm/include/llvm/ADT/SmallVector.h:145: T& llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::operator[](llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type) [with T = std::unique_ptr<llvm::MCParsedAsmOperand>; <template-parameter-1-2> = void; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::reference = std::unique_ptr<llvm::MCParsedAsmOperand>&; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type = long unsigned int]: Assertion `idx < size()' failed.

$ ./crash-03-invalid-index
/path/to/llvm/include/llvm/ADT/StringRef.h:207: char llvm::StringRef::operator[](size_t) const: Assertion `Index < Length && "Invalid index!"' failed.

$ ./crash-04-readcount-not-equal-to-one
/path/to/llvm/include/llvm/MC/MCParser/MCAsmLexer.h:179: const llvm::AsmToken llvm::MCAsmLexer::peekTok(bool): Assertion `ReadCount == 1' failed.

$ ./crash-05-normal-symbols-cannot-be-unnamed
/path/to/llvm/lib/MC/MCContext.cpp:114: llvm::MCSymbol* llvm::MCContext::getOrCreateSymbol(const llvm::Twine&): Assertion `!NameRef.empty() && "Normal symbols cannot be unnamed!"' failed.

$ ./crash-06-exponent-has-no-digits-in-apfloat-line-126
/path/to/llvm/lib/Support/APFloat.cpp:126: int readExponent(llvm::StringRef::iterator, llvm::StringRef::iterator): Assertion `p != end && "Exponent has no digits"' failed.

$ ./crash-07-exponent-has-no-digits-in-apfloat-line-131
/path/to/llvm/lib/Support/APFloat.cpp:131: int readExponent(llvm::StringRef::iterator, llvm::StringRef::iterator): Assertion `p != end && "Exponent has no digits"' failed.

$ ./crash-08-invalid-character-in-exponent-absexponent-case
/path/to/llvm/lib/Support/APFloat.cpp:135: int readExponent(llvm::StringRef::iterator, llvm::StringRef::iterator): Assertion `absExponent < 10U && "Invalid character in exponent"' failed.

$ ./crash-09-invalid-character-in-exponent-value-case
/path/to/llvm/lib/Support/APFloat.cpp:141: int readExponent(llvm::StringRef::iterator, llvm::StringRef::iterator): Assertion `value < 10U && "Invalid character in exponent"' failed.

$ ./crash-10-stringref-cannot-be-built-from-a-null-argument
/path/to/llvm/include/llvm/ADT/StringRef.h:73: llvm::StringRef::StringRef(const char*): Assertion `Str && "StringRef cannot be built from a NULL argument"' failed.

$ ./crash-11-elfobjectwriter-should-not-have-constructed-this
/path/to/llvm/lib/MC/ELFObjectWriter.cpp:626: virtual void {anonymous}::ELFObjectWriter::recordRelocation(llvm::MCAssembler&, const llvm::MCAsmLayout&, const llvm::MCFragment*, const llvm::MCFixup&, llvm::MCValue, bool&, uint64_t&): Assertion `RefB->getKind() == MCSymbolRefExpr::VK_None && "Should not have constructed this"' failed.

$ ./crash-12-cannot-set-a-variable-that-has-already-been-used
/path/to/llvm/lib/MC/MCSymbol.cpp:44: void llvm::MCSymbol::setVariableValue(const llvm::MCExpr*): Assertion `!IsUsed && "Cannot set a variable that has already been used."' failed.

$ ./crash-13-hexagon-mc-code-emitter-mk-is-not-equal-to-symbolref
/path/to/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCodeEmitter.cpp:410: unsigned int llvm::HexagonMCCodeEmitter::getExprOpValue(const llvm::MCInst&, const llvm::MCOperand&, const llvm::MCExpr*, llvm::SmallVectorImpl<llvm::MCFixup>&, const llvm::MCSubtargetInfo&) const: Assertion `MK == MCExpr::SymbolRef' failed.
```
