### PR TITLE
The aarch64 target is actually little endian.

### DIFF
--- a/bindings/python/sample.py
+++ b/bindings/python/sample.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     test_ks(KS_ARCH_ARM, KS_MODE_THUMB + KS_MODE_BIG_ENDIAN, b"movs r4, #0xf0")
 
     # ARM64
-    test_ks(KS_ARCH_ARM64, KS_MODE_BIG_ENDIAN, b"ldr w1, [sp, #0x8]")
+    test_ks(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN, b"ldr w1, [sp, #0x8]")
 
     # Hexagon
     test_ks(KS_ARCH_HEXAGON, KS_MODE_BIG_ENDIAN, b"v23.w=vavg(v11.w,v2.w):rnd")

--- a/bindings/ruby/sample.rb
+++ b/bindings/ruby/sample.rb
@@ -36,7 +36,7 @@ test_ks(KS_ARCH_ARM, KS_MODE_THUMB, "movs r4, #0xf0")
 test_ks(KS_ARCH_ARM, KS_MODE_THUMB + KS_MODE_BIG_ENDIAN, "movs r4, #0xf0")
 
 # ARM64
-test_ks(KS_ARCH_ARM64, KS_MODE_BIG_ENDIAN, "ldr w1, [sp, #0x8]")
+test_ks(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN, "ldr w1, [sp, #0x8]")
 
 # Hexagon
 test_ks(KS_ARCH_HEXAGON, KS_MODE_BIG_ENDIAN, "v23.w=vavg(v11.w,v2.w):rnd")

--- a/kstool/kstool.cpp
+++ b/kstool/kstool.cpp
@@ -146,8 +146,8 @@ int main(int argc, char **argv)
         err = ks_open(KS_ARCH_ARM, KS_MODE_THUMB+KS_MODE_BIG_ENDIAN, &ks);
     }
 
-    if (!strcmp(mode, "arm64be") || !strcmp(mode, "arm64")) {
-        err = ks_open(KS_ARCH_ARM64, KS_MODE_BIG_ENDIAN, &ks);
+    if (!strcmp(mode, "arm64")) {
+        err = ks_open(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN, &ks);
     }
 
     if (!strcmp(mode, "hex") || !strcmp(mode, "hexagon")) {

--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -278,7 +278,7 @@ ks_err ks_open(ks_arch arch, int mode, ks_engine **result)
 
 #ifdef LLVM_ENABLE_ARCH_AArch64
             case KS_ARCH_ARM64:
-                if (mode != KS_MODE_BIG_ENDIAN) {
+                if (mode != KS_MODE_LITTLE_ENDIAN) {
                     delete ks;
                     return KS_ERR_MODE;
                 }

--- a/samples/sample.c
+++ b/samples/sample.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
     test_ks(KS_ARCH_ARM, KS_MODE_THUMB + KS_MODE_BIG_ENDIAN, "movs r4, #0xf0", 0);
 
     // ARM64
-    test_ks(KS_ARCH_ARM64, KS_MODE_BIG_ENDIAN, "ldr w1, [sp, #0x8]", 0);
+    test_ks(KS_ARCH_ARM64, KS_MODE_LITTLE_ENDIAN, "ldr w1, [sp, #0x8]", 0);
 
     // Hexagon
     test_ks(KS_ARCH_HEXAGON, KS_MODE_BIG_ENDIAN, "v23.w=vavg(v11.w,v2.w):rnd", 0);


### PR DESCRIPTION
This can easily be demonstrated by looking at the byte order of:

```
$ kstool arm64 ".word 0x12345678"
.word 0x12345678 = [ 78 56 34 12 ]
```

llvm-mc also seems to define an `aarch64_be` target which would be the big endian variant, but while the data is indeed in big endian order in that mode, the actual opcodes aren't.
