### PR TITLE
Add three assertion failure crashers.

### DIFF
--- a/suite/regress/c-crashers/crash-14-invalid-accessor.c
+++ b/suite/regress/c-crashers/crash-14-invalid-accessor.c
@@ -1,0 +1,18 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'A', 'A', 'F', '=', 'A', 'A', '-', '-', 'A', 0x0a,
+    'F', '=', 'A', 'd', '-', '5', ';', '.', '=', 'A',
+    'A', 'F', '-', 'A', 'A', 'F', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-15-expected-macro-to-be-defined.c
+++ b/suite/regress/c-crashers/crash-15-expected-macro-to-be-defined.c
@@ -1,0 +1,18 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    0x12, ';', 0x12, 'i', ';', '.', 'i', 'R', 'p', ' ',
+    'e', 'm', 'i', 'R', 'p', ',', 0xca, 0xe9, ',', 'I',
+    '=', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-16-expression-value-must-be-representable-in-32-bits.c
+++ b/suite/regress/c-crashers/crash-16-expression-value-must-be-representable-in-32-bits.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_ARM, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    ' ', 'e', 'o', 'r', ' ', 'A', '1', ',', '.', '2', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}


### PR DESCRIPTION
Add three assertion failure crashers.

```
$ ./crash-14-invalid-accessor
/path/to/llvm/include/llvm/MC/MCSymbol.h:265: llvm::MCSection& llvm::MCSymbol::getSection(bool) const: Assertion `isInSection(SetUsed) && "Invalid accessor!"' failed.

$ ./crash-15-expected-macro-to-be-defined
/path/to/llvm/lib/MC/MCParser/AsmParser.cpp:2339: bool {anonymous}::AsmParser::parseMacroArguments(const {anonymous}::MCAsmMacro*, {anonymous}::MCAsmMacroArguments&): Assertion `M && "expected macro to be defined"' failed.

$ ./crash-16-expression-value-must-be-representable-in-32-bits
/path/to/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp:10117: virtual unsigned int {anonymous}::ARMAsmParser::validateTargetOperandClass(llvm::MCParsedAsmOperand&, unsigned int): Assertion `(Value >= (-2147483647-1) && Value <= (4294967295U)) && "expression value must be representable in 32 bits"' failed.
```
