### PR TITLE
Add two assertion failure crashers.

### DIFF
--- a/suite/regress/c-crashers/crash-17-invalid-size.c
+++ b/suite/regress/c-crashers/crash-17-invalid-size.c
@@ -1,0 +1,22 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_ARM, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'L', 'D', 'r', ' ', 'A', 'H', '1', 'I', ',', '=',
+    'j', 'H', 'G', 'Q', ',', '=', '2', ',', '=', 'r',
+    ',', '=', 'G', 'Q', ',', '=', '1', '1', '1', '1',
+    '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
+    '1', '2', ',', '=', 'e', 'y', ',', '=', '2', ',',
+    '=', 'e', 'Q', ',', '=', 'r', 'Q', ',', '=', 'r',
+    ',', '=', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}

--- a/suite/regress/c-crashers/crash-18-invalid-access.c
+++ b/suite/regress/c-crashers/crash-18-invalid-access.c
@@ -1,0 +1,17 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_ARM, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    'C', 'p', 'S', 'Q', 'H', 'K', ' ', 'a', 'S', 'R',
+    ' ', 'C', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}


### PR DESCRIPTION
Add two assertion failure crashers:

```
$ ./crash-17-invalid-size
/path/to/llvm/lib/MC/MCStreamer.cpp:84: virtual void llvm::MCStreamer::EmitIntValue(uint64_t, unsigned int): Assertion `(isUIntN(8 * Size, Value) || isIntN(8 * Size, Value)) && "Invalid size"' failed.
$ ./crash-18-invalid-access
/path/to/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp:608: llvm::StringRef {anonymous}::ARMOperand::getToken() const: Assertion `Kind == k_Token && "Invalid access!"' failed.
```
