### PR TITLE
Add segfault crash case crash-20-segfault-in-llvm-mcassembler-computefragmentsize.c

### DIFF
--- a/suite/regress/c-crashers/crash-20-segfault-in-llvm-mcassembler-computefragmentsize.c
+++ b/suite/regress/c-crashers/crash-20-segfault-in-llvm-mcassembler-computefragmentsize.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_SYSTEMZ, ks_mode = KS_MODE_LITTLE_ENDIAN;
+  unsigned char assembly[] = {
+    '.', '=', 'A', 0x0a, 'A', ':', '.', ']', 0x00,
+  };
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    ks_asm(ks, (char *)assembly, 0, &insn, &size, &count);
+    ks_free(insn);
+  }
+  ks_close(ks);
+}


### PR DESCRIPTION
Add segfault crash case `crash-20-segfault-in-llvm-mcassembler-computefragmentsize.c`
