### PR TITLE
Add test status script.

### DIFF
--- a/suite/regress/c-crashers/run-all-overview.sh
+++ b/suite/regress/c-crashers/run-all-overview.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+readonly COLOR_RED="\e[31m"
+readonly COLOR_GREEN="\e[32m"
+readonly COLOR_BOLD="\e[1m"
+readonly COLOR_NORMAL_DISPLAY="\e[0m"
+
+echo
+printf "== %b ==\n" "${COLOR_BOLD}keystone engine crashers${COLOR_NORMAL_DISPLAY}"
+echo
+num_crashed=0
+num_tests=0
+for crash_case in $(find . -name "crash-??-*" -not -name "*.sh" -type f | sort -n); do
+  if [[ ! -x ${crash_case} ]]; then
+    continue
+  fi
+  num_tests=$((num_tests + 1))
+  { $crash_case; } > /dev/null 2> /dev/null
+  if [[ $? == 0 ]]; then
+    printf "  %b  %b\n" "${COLOR_GREEN}✓${COLOR_NORMAL_DISPLAY}" "${crash_case}"
+  else
+    num_crashed=$((num_crashed + 1))
+    printf "  %b  %b\n" "${COLOR_RED}✘${COLOR_NORMAL_DISPLAY}" "${crash_case}"
+  fi
+done
+if [[ ${num_tests} == 0 ]]; then
+    echo "No tests to process. Please run 'make' to build the tests."
+    echo
+    exit
+fi
+echo
+printf "** Results: %b of %b tests resulted in a crash **\n" "${COLOR_BOLD}${num_crashed}${COLOR_NORMAL_DISPLAY}" "${COLOR_BOLD}${num_tests}${COLOR_NORMAL_DISPLAY}"
+echo


### PR DESCRIPTION
```
$ ./run-all-overview.sh

== keystone engine crashers ==

  ✘  ./crash-01-empty-tombstone-value-shouldnt-be-inserted-into-map
  ✘  ./crash-02-index-lt-size-failed
  ✘  ./crash-03-invalid-index
  ✘  ./crash-04-readcount-not-equal-to-one
  ✘  ./crash-05-normal-symbols-cannot-be-unnamed
  ✓  ./crash-06-exponent-has-no-digits-in-apfloat-line-126
  ✓  ./crash-07-exponent-has-no-digits-in-apfloat-line-131
  ✓  ./crash-08-invalid-character-in-exponent-absexponent-case
  ✓  ./crash-09-invalid-character-in-exponent-value-case
  ✘  ./crash-10-stringref-cannot-be-built-from-a-null-argument
  ✘  ./crash-11-elfobjectwriter-should-not-have-constructed-this
  ✘  ./crash-12-cannot-set-a-variable-that-has-already-been-used
  ✘  ./crash-13-hexagon-mc-code-emitter-mk-is-not-equal-to-symbolref
  ✘  ./crash-14-invalid-accessor
  ✘  ./crash-15-expected-macro-to-be-defined
  ✓  ./crash-16-expression-value-must-be-representable-in-32-bits
  ✘  ./crash-17-invalid-size
  ✘  ./crash-18-invalid-access
  ✘  ./crash-19-unable-to-encode-mcoperand
  ✘  ./crash-20-segfault-in-llvm-mcassembler-computefragmentsize

** Results: 15 of 20 tests resulted in a crash **

$
```
