### PR TITLE
Changed argument types for ks_option and ks_free functions

### DIFF
--- a/bindings/python/keystone/keystone.py
+++ b/bindings/python/keystone/keystone.py
@@ -100,10 +100,10 @@ _setup_prototype(_ks, "ks_open", kserr, c_uint, c_uint, POINTER(ks_engine))
 _setup_prototype(_ks, "ks_close", kserr, ks_engine)
 _setup_prototype(_ks, "ks_strerror", c_char_p, kserr)
 _setup_prototype(_ks, "ks_errno", kserr, ks_engine)
-_setup_prototype(_ks, "ks_option", kserr, ks_engine, c_int, c_void_p)
+_setup_prototype(_ks, "ks_option", kserr, ks_engine, c_int, c_size_t)
 # int ks_asm(ks_engine *ks, const char *string, uint64_t address, unsigned char **encoding, size_t *encoding_size, size_t *stat_count);
 _setup_prototype(_ks, "ks_asm", c_int, ks_engine, c_char_p, c_uint64, POINTER(POINTER(c_ubyte)), POINTER(c_size_t), POINTER(c_size_t))
-_setup_prototype(_ks, "ks_free", None, c_void_p)
+_setup_prototype(_ks, "ks_free", None, POINTER(c_ubyte))
 
 
 # access to error code via @errno of KsError

--- a/include/keystone/keystone.h
+++ b/include/keystone/keystone.h
@@ -302,7 +302,7 @@ int ks_asm(ks_engine *ks,
  @p: memory allocated in @encoding argument of ks_asm()
 */
 KEYSTONE_EXPORT
-void ks_free(void *p);
+void ks_free(unsigned char *p);
 
 
 #ifdef __cplusplus

--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -511,7 +511,7 @@ ks_err ks_option(ks_engine *ks, ks_opt_type type, size_t value)
 
 
 KEYSTONE_EXPORT
-void ks_free(void *p)
+void ks_free(unsigned char *p)
 {
     free(p);
 }


### PR DESCRIPTION
* ~~`ks_option`: The 'value' argument should have type `ks_opt_value`~~
* `ks_free`: The 'p' argument should have type `unsigned char*` to match the type of the 'encoding' argument to `ks_asm`

This doesn't change any functionality, but IMO is more "correct" (in regards to the type system) and adds clarity to the header file.

~~I've made minor adjustments to the different bindings, but I'm by no means an expert in most of those languages, so it would be good to have the original authors review and let me know if I've broken anything. Pinging @nl5887, @iksteen, and @sashs~~