### PR TITLE
Add crash case: crash-38-x64-cast-ty-argument-of-incompatible-type.c

### DIFF
--- a/suite/regress/c-crashers/crash-38-x64-cast-ty-argument-of-incompatible-type.c
+++ b/suite/regress/c-crashers/crash-38-x64-cast-ty-argument-of-incompatible-type.c
@@ -1,0 +1,16 @@
+#include <keystone/keystone.h>
+int main(int argc, char **argv) {
+  int ks_arch = KS_ARCH_X86, ks_mode = KS_MODE_64;
+  char *assembly = ".bss\n.int(0-a)";
+  ks_engine *ks;
+  ks_err err = ks_open(ks_arch, ks_mode, &ks);
+  if (!err) {
+    size_t count, size;
+    unsigned char *insn;
+    if (ks_asm(ks, (char *)assembly, 0, &insn, &size, &count))
+      printf("ERROR: failed on ks_asm() with error = %s, code = %u\n", ks_strerror(ks_errno(ks)), ks_errno(ks));
+    ks_free(insn);
+  }
+  ks_close(ks);
+  return 0;
+}


### PR DESCRIPTION
```
$ ./crash-38-x64-cast-ty-argument-of-incompatible-type
/path/to/llvm/include/llvm/Support/Casting.h:230: typename llvm::cast_retty<To, From>::ret_type llvm::cast(Y&) [with X = llvm::MCSectionELF; Y = llvm::MCSection; typename llvm::cast_retty<To, From>::ret_type = llvm::MCSectionELF&]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
Aborted
```