### PR TITLE
python 2/3 compatibility in KsError.__str__ and Ks.asm

### DIFF
--- a/bindings/python/keystone/keystone.py
+++ b/bindings/python/keystone/keystone.py
@@ -110,9 +110,12 @@ _setup_prototype(_ks, "ks_free", None, POINTER(c_ubyte))
 class KsError(Exception):
     def __init__(self, errno):
         self.errno = errno
+        self.message = _ks.ks_strerror(self.errno)
+        if not isinstance(self.message, str) and isinstance(self.message, bytes):
+            self.message = self.message.decode('utf-8')
 
     def __str__(self):
-        return _ks.ks_strerror(self.errno)
+        return self.message
 
 
 # return the core's version
@@ -189,6 +192,9 @@ class Ks(object):
         encode = POINTER(c_ubyte)()
         encode_size = c_size_t()
         stat_count = c_size_t()
+        if not isinstance(string, bytes) and isinstance(string, str):
+            string = string.encode('ascii')
+
         status = _ks.ks_asm(self._ksh, string, addr, byref(encode), byref(encode_size), byref(stat_count))
         if (status != 0):
             errno = _ks.ks_errno(self._ksh)


### PR DESCRIPTION
In python 3 it was only possible to give a bytes string to asm (b'jmp esp'). If string was given to this function you got just the message "<wrong type>". Now you can give bytes or a string. 

If an KsError was raised and you wanted to cast it to str, another Error was raised, because ks_strerror returned an object of type bytes. 