### PR TITLE
go: Update to latest keystone package API & Remove unnecessary else

### DIFF
--- a/bindings/go/keystone/samples/main.go
+++ b/bindings/go/keystone/samples/main.go
@@ -14,19 +14,19 @@ import (
 func main() {
 	assembly := os.Args[1]
 
-	if ks, err := keystone.New(keystone.ArchitectureX86, keystone.Mode32); err != nil {
+	ks, err := keystone.New(keystone.ARCH_X86, keystone.MODE_32)
+	if err != nil {
 		panic(err)
+	}
+	defer ks.Close()
+
+	if err := ks.Option(keystone.OPT_SYNTAX, keystone.OPT_SYNTAX_INTEL); err != nil {
+		panic(fmt.Errorf("Could not set syntax option to intel"))
+	}
+
+	if insn, _, ok := ks.Assemble(assembly, 0); !ok {
+		panic(fmt.Errorf("Could not assemble instruction"))
 	} else {
-		defer ks.Close()
-
-		if err := ks.Option(keystone.OptionSyntax, keystone.OptionSyntaxIntel); err != nil {
-			panic(fmt.Errorf("Could not set syntax option to intel"))
-		}
-
-		if insn, _, ok := ks.Assemble(assembly, 0); !ok {
-			panic(fmt.Errorf("Could not assemble instruction"))
-		} else {
-			fmt.Printf("%s: [%x]", assembly, insn)
-		}
+		fmt.Printf("%s: [%x]", assembly, insn)
 	}
 }

--- a/bindings/go/keystone/samples/main.go
+++ b/bindings/go/keystone/samples/main.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	keystone "github.com/keystone-engine/beta/bindings/go/keystone"
+	"github.com/keystone-engine/keystone/bindings/go/keystone"
 )
 
 func main() {


### PR DESCRIPTION
Update and Fix go binding sample.

- Currently, can't compiling because not found some of the const variables
 - but I do not yet understand keystone C(++) side behavior. Please point out if I am wrong.

- `panic` built-in function always exit to the program. Remove else and export `ks` variable in the main function