### PR TITLE
[haskell bindings] Updated transformers dependency to work with GHC 8

### DIFF
--- a/bindings/haskell/keystone.cabal
+++ b/bindings/haskell/keystone.cabal
@@ -27,7 +27,7 @@ library
   other-modules:       Keystone.Internal.Util
   build-depends:       base >= 4 && < 5,
                        bytestring >= 0.9.1,
-                       transformers <= 0.5,
+                       transformers < 0.6,
                        either >= 4.4
   hs-source-dirs:      src
   c-sources:           src/cbits/keystone_wrapper.c


### PR DESCRIPTION
Same as Unicorn PR #637 (https://github.com/unicorn-engine/unicorn/pull/637).

Need to update the transformers dependency to get the Haskell bindings compiling with GHC 8.x