### PR TITLE
initialize variables correctly in ks_struct. closes #250

### DIFF
--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -249,22 +249,12 @@ ks_err ks_open(ks_arch arch, int mode, ks_engine **result)
     std::string TripleName = "";
 
     if (arch < KS_ARCH_MAX) {
-        ks = new (std::nothrow) ks_struct();
+        ks = new (std::nothrow) ks_struct(arch, mode, KS_ERR_OK, KS_OPT_SYNTAX_INTEL);
         
         if (!ks) {
             // memory insufficient
             return KS_ERR_NOMEM;
         }
-        
-        ks->TheTarget = NULL;
-        ks->MAB = NULL;
-        ks->MRI = NULL;
-        ks->MAI = NULL;
-        ks->MCII = NULL;
-        ks->STI = NULL;
-        ks->errnum = KS_ERR_OK;
-        ks->arch = arch;
-        ks->mode = mode;
 
         switch(arch) {
             default: break;

--- a/llvm/keystone/ks_priv.h
+++ b/llvm/keystone/ks_priv.h
@@ -43,19 +43,22 @@ struct ks_struct {
     unsigned int errnum;
     ks_opt_value syntax;
 
-    ks_args_ks_t init_arch;
-    const Target *TheTarget;
+    ks_args_ks_t init_arch = nullptr;
+    const Target *TheTarget = nullptr;
     std::string TripleName;
     SourceMgr SrcMgr;
-    MCAsmBackend *MAB;
+    MCAsmBackend *MAB = nullptr;
     MCTargetOptions MCOptions;
-    MCRegisterInfo *MRI;
-    MCAsmInfo *MAI;
-    MCInstrInfo *MCII;
+    MCRegisterInfo *MRI = nullptr;
+    MCAsmInfo *MAI = nullptr;
+    MCInstrInfo *MCII = nullptr;
     std::string FeaturesStr;
-    MCSubtargetInfo *STI;
+    MCSubtargetInfo *STI = nullptr;
     MCObjectFileInfo MOFI;
-    ks_sym_resolver sym_resolver;
+    ks_sym_resolver sym_resolver = nullptr;
+
+    ks_struct(ks_arch arch, int mode, unsigned int errnum, ks_opt_value syntax)
+        : arch(arch), mode(mode), errnum(errnum), syntax(syntax) { }
 };
 
 


### PR DESCRIPTION
various members of the `ks_struct` ( `mode` and `sym_resolver`) were not initialized with default values and this causes undefined behavior (issue #250)