### PR TITLE
Update nix compile docs to use lib64 option

### DIFF
--- a/docs/COMPILE-NIX.md
+++ b/docs/COMPILE-NIX.md
@@ -29,7 +29,7 @@ For Windows, see [COMPILE-WINDOWS.md](COMPILE-WINDOWS.md)
 
    For Linux distributions following the "Filesystem Hierarchy Standard" and
    put x64 libraries under $PREFIX/lib64, such as Fedora, Redhat & Suse,
-   add "fhs" option at the end of make-share.sh script, like below.
+   add "lib64" option at the end of make-share.sh script, like below.
 
         $ ../make-share.sh lib64
 
@@ -54,7 +54,7 @@ For Windows, see [COMPILE-WINDOWS.md](COMPILE-WINDOWS.md)
 
    For Linux distributions following the "Filesystem Hierarchy Standard" and
    put x64 libraries under $PREFIX/lib64, such as Fedora, Redhat & Suse,
-   add "fhs" option at the end of make-share.sh script, like below.
+   add "lib64" option at the end of make-share.sh script, like below.
 
         $ ../make-lib.sh lib64
 

--- a/docs/COMPILE-NIX.md
+++ b/docs/COMPILE-NIX.md
@@ -31,7 +31,7 @@ For Windows, see [COMPILE-WINDOWS.md](COMPILE-WINDOWS.md)
    put x64 libraries under $PREFIX/lib64, such as Fedora, Redhat & Suse,
    add "fhs" option at the end of make-share.sh script, like below.
 
-        $ ../make-share.sh fhs
+        $ ../make-share.sh lib64
 
    By default, this builds all architectures, which is: AArch64, ARM, Hexagon,
    Mips, PowerPC, Sparc, SystemZ & X86. To compile just some selected ones,
@@ -56,7 +56,7 @@ For Windows, see [COMPILE-WINDOWS.md](COMPILE-WINDOWS.md)
    put x64 libraries under $PREFIX/lib64, such as Fedora, Redhat & Suse,
    add "fhs" option at the end of make-share.sh script, like below.
 
-        $ ../make-lib.sh fhs
+        $ ../make-lib.sh lib64
 
    Like above, this builds all architectures. To compile just some selected ones,
    pass a semicolon-separated list of targets to LLVM_TARGETS_TO_BUILD,


### PR DESCRIPTION
The 'fhs' build option has been renamed to 'lib64'