### PR TITLE
ARM64(llvm): Disable range checking on instructions with a PC-relative offset

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -768,9 +768,7 @@ public:
     if (!MCE)
       return true;
     int64_t Val = MCE->getValue();
-    if (Val & 0x3)
-      return false;
-    return (Val >= -(0x2000000 << 2) && Val <= (0x1ffffff << 2));
+    return ((Val & 0x3) == 0);
   }
   bool isPCRelLabel19() const {
     if (!isImm())
@@ -779,9 +777,7 @@ public:
     if (!MCE)
       return true;
     int64_t Val = MCE->getValue();
-    if (Val & 0x3)
-      return false;
-    return (Val >= -(0x40000 << 2) && Val <= (0x3ffff << 2));
+    return ((Val & 0x3) == 0);
   }
   bool isBranchTarget14() const {
     if (!isImm())
@@ -790,9 +786,7 @@ public:
     if (!MCE)
       return true;
     int64_t Val = MCE->getValue();
-    if (Val & 0x3)
-      return false;
-    return (Val >= -(0x2000 << 2) && Val <= (0x1fff << 2));
+    return ((Val & 0x3) == 0);
   }
 
   bool


### PR DESCRIPTION
(b/bl/cbz/cbnz/tbz/tbnz/ldr/ldrsw/prfm)