### PR TITLE
Fix issue #293

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -712,12 +712,13 @@ size_t AsmParser::Run(bool NoInitialTextSection, uint64_t Address, bool NoFinali
     //printf(">> 222 error = %u\n", Info.KsError);
     if (!KsError)
         KsError = Info.KsError;
+        return 0;
 
     // We had an error, validate that one was emitted and recover by skipping to
     // the next line.
     // assert(HadError && "Parse statement returned an error, but none emitted!");
 
-    eatToEndOfStatement();
+    //eatToEndOfStatement();
   }
 
   if (TheCondState.TheCond != StartingCondState.TheCond ||

--- a/suite/regress/x86_issue293.py
+++ b/suite/regress/x86_issue293.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+# Fill in the information in the form below when you create a new regression
+
+# Github issue: #293
+# Author: Aaron Adams
+
+from keystone import *
+
+import regress
+
+class TestX86(regress.RegressTest):
+    def runTest(self):
+        # Initialize Keystone engine
+        ks = Ks(KS_ARCH_X86, KS_MODE_32)
+        # Assemble to get back insn encoding & statement count
+        try:
+            # An exception should be raised from the jnz exit:; being bad
+            encoding, count = ks.asm(b"jnz exit:; add eax, ebx; exit: ret")
+        except Exception, e:
+            return
+        raise Exception
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
Removed a debug statement that was preventing correct errors from being thrown when bad instructions were followed by good instructions.

With the fix:
```
$ build/kstool/kstool x32 "jnz exit:; xor eax, eax; xor ebx, ebx"
ERROR: failed on ks_asm() with count = 0, error = 'Invalid operand (KS_ERR_ASM_INVALIDOPERAND)' (code = 512)
```

Without the fix:
```
$ build/kstool/kstool x32 "jnz exit:; xor eax, eax; xor ebx, ebx"
jnz exit:; xor eax, eax; xor ebx, ebx = [ 31 c0 31 db ]
```

Regression test with fix:
```
~/src/keystone$ suite/regress/x86_issue293.py 
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```
Regression test without fix:
```
~src/keystone$ suite/regress/x86_issue293.py 
E
======================================================================
ERROR: runTest (__main__.TestX86)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "suite/regress/x86_issue293.py", line 22, in runTest
    raise Exception
Exception

----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
```



