### PR TITLE
bindings: make the sample code in README.md for Rust compilable

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -4,19 +4,23 @@ Rust bindings for the [keystone](http://www.keystone-engine.org/) engine.
 ## Sample
 ```rust
 extern crate keystone;
-use keystone::{Keystone, Arch, Mode, OptionType, OptionValue};
+use keystone::*;
 
 fn main() {
-    let engine = Keystone::new(Arch::X86, Mode::Mode32)
+    let engine = Keystone::new(Arch::X86, MODE_32)
         .expect("Could not initialize Keystone engine");
 
-    engine.option(OptionType::Syntax, OptionValue::SyntaxNASM)
+    engine.option(OptionType::SYNTAX, OPT_SYNTAX_NASM)
         .expect("Could not set option to nasm syntax");
 
     let result = engine.asm("mov ah, 0x80".to_string(), 0)
         .expect("Could not assemble");
 
-    let _ = result;
+    println!("ASM result: {}", result);
+
+    if let Err(err) = engine.asm("INVALID".to_string(), 0) {
+        println!("Error: {}", err);
+    }
 }
 ```
 


### PR DESCRIPTION
Currently, the sample code in [/bindings/rust/README.md](https://github.com/keystone-engine/keystone/blob/master/bindings/rust/README.md) cannot be compiled.
I just copied the content of [/bindings/rust/examples/asm.rs](https://github.com/keystone-engine/keystone/blob/master/bindings/rust/examples/asm.rs) into the README.md and it can be compiled well.