### PR TITLE
Add asm(..., as_bytes=True) to Python bindings

### DIFF
--- a/bindings/python/keystone/keystone.py
+++ b/bindings/python/keystone/keystone.py
@@ -200,7 +200,7 @@ class Ks(object):
 
 
     # assemble a string of assembly
-    def asm(self, string, addr = 0):
+    def asm(self, string, addr=0, as_bytes=False):
         encode = POINTER(c_ubyte)()
         encode_size = c_size_t()
         stat_count = c_size_t()
@@ -215,9 +215,13 @@ class Ks(object):
             if stat_count.value == 0:
                 return (None, 0)
             else:
-                encoding = []
-                for i in range(encode_size.value):
-                    encoding.append(encode[i])
+                if as_bytes:
+                    encoding = string_at(encode, encode_size.value)
+                else:
+                    encoding = []
+                    for i in range(encode_size.value):
+                        encoding.append(encode[i])
+
                 _ks.ks_free(encode)
                 return (encoding, stat_count.value)
 


### PR DESCRIPTION
When enabled, the assembled code will be returned as `bytes` (`str` on Python 2) instead of a list of integers, this is more memory efficient, faster (It's created using `ctypes.string_at` instead of a loop in Python), and more convenient since that's the type that most code that works with bytes in Python expects (That includes capstone).

Defaults to `False` for backwards compatibility, since changing the return type is a breaking change.

Please take into consideration whether this API is OK and if it indeed should default to `False`.