### PR TITLE
Add *.egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.class
 *.jar
 *.pyc
+*.egg-info
 *.tgz
 *.tar.gz
 *.github.io


### PR DESCRIPTION
This is a meta data folder generated by Python's setuptools.