### PR TITLE
rename namespace "llvm" to "llvm_ks"

### DIFF
--- a/llvm/include/llvm-c/Types.h
+++ b/llvm/include/llvm-c/Types.h
@@ -21,7 +21,7 @@ extern "C" {
 /**
  * Used to pass regions of memory through LLVM interfaces.
  *
- * @see llvm::MemoryBuffer
+ * @see llvm_ks::MemoryBuffer
  */
 typedef struct LLVMOpaqueMemoryBuffer *LLVMMemoryBufferRef;
 

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -19,7 +19,7 @@
 
 #include "llvm/ADT/APInt.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 struct fltSemantics;
 class APSInt;
@@ -681,6 +681,6 @@ inline APFloat maxnum(const APFloat &A, const APFloat &B) {
   return (A.compare(B) == APFloat::cmpLessThan) ? B : A;
 }
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif // LLVM_ADT_APFLOAT_H

--- a/llvm/include/llvm/ADT/APInt.h
+++ b/llvm/include/llvm/ADT/APInt.h
@@ -24,7 +24,7 @@
 #include <cstring>
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class FoldingSetNodeID;
 class StringRef;
 class hash_code;
@@ -1362,7 +1362,7 @@ public:
   unsigned countLeadingZeros() const {
     if (isSingleWord()) {
       unsigned unusedBits = APINT_BITS_PER_WORD - BitWidth;
-      return llvm::countLeadingZeros(VAL) - unusedBits;
+      return llvm_ks::countLeadingZeros(VAL) - unusedBits;
     }
     return countLeadingZerosSlowCase();
   }
@@ -1403,7 +1403,7 @@ public:
   /// of ones from the least significant bit to the first zero bit.
   unsigned countTrailingOnes() const {
     if (isSingleWord())
-      return llvm::countTrailingOnes(VAL);
+      return llvm_ks::countTrailingOnes(VAL);
     return countTrailingOnesSlowCase();
   }
 
@@ -1415,7 +1415,7 @@ public:
   /// \returns 0 if the value is zero, otherwise returns the number of set bits.
   unsigned countPopulation() const {
     if (isSingleWord())
-      return llvm::countPopulation(VAL);
+      return llvm_ks::countPopulation(VAL);
     return countPopulationSlowCase();
   }
 

--- a/llvm/include/llvm/ADT/APSInt.h
+++ b/llvm/include/llvm/ADT/APSInt.h
@@ -17,7 +17,7 @@
 
 #include "llvm/ADT/APInt.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class APSInt : public APInt {
   bool IsUnsigned;
@@ -337,6 +337,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, const APSInt &I) {
   return OS;
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -15,7 +15,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
   /// ArrayRef - Represent a constant reference to an array (0 or more elements
   /// consecutively in memory), i.e. a start pointer and a length.  It allows
   /// various APIs to take consecutive elements easily and conveniently.
@@ -379,6 +379,6 @@ namespace llvm {
   template <typename T> hash_code hash_value(ArrayRef<T> S) {
     return hash_combine_range(S.begin(), S.end());
   }
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_ADT_ARRAYREF_H

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -30,7 +30,7 @@
 #include <new>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace detail {
 // We extend a pair to allow users to override the bucket type with their own
@@ -1069,6 +1069,6 @@ capacity_in_bytes(const DenseMap<KeyT, ValueT, KeyInfoT> &X) {
   return X.getMemorySize();
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/PointerLikeTypeTraits.h"
 #include "llvm/Support/type_traits.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 template<typename T>
 struct DenseMapInfo {
@@ -216,6 +216,6 @@ template <typename T> struct DenseMapInfo<ArrayRef<T>> {
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -16,7 +16,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace detail {
 struct DenseSetEmpty {};
@@ -160,6 +160,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/EpochTracker.h
+++ b/llvm/include/llvm/ADT/EpochTracker.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace llvm {
+namespace llvm_ks {
 
 #ifndef LLVM_ENABLE_ABI_BREAKING_CHECKS
 
@@ -94,6 +94,6 @@ public:
 
 #endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/FoldingSet.h
+++ b/llvm/include/llvm/ADT/FoldingSet.h
@@ -22,7 +22,7 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 /// This folding set used for two purposes:
 ///   1. Given information about a node we want to create, look up the unique
 ///      instance of the node in the set.  If the node already exists, return
@@ -468,7 +468,7 @@ public:
 ///
 /// T must be a subclass of FoldingSetNode and implement a Profile
 /// function with signature
-///   void Profile(llvm::FoldingSetNodeID &, Ctx);
+///   void Profile(llvm_ks::FoldingSetNodeID &, Ctx);
 template <class T, class Ctx>
 class ContextualFoldingSet final : public FoldingSetImpl {
   // Unfortunately, this can't derive from FoldingSet<T> because the
@@ -739,11 +739,11 @@ template<typename T> struct FoldingSetTrait<T*> {
 template <typename T1, typename T2>
 struct FoldingSetTrait<std::pair<T1, T2>> {
   static inline void Profile(const std::pair<T1, T2> &P,
-                             llvm::FoldingSetNodeID &ID) {
+                             llvm_ks::FoldingSetNodeID &ID) {
     ID.Add(P.first);
     ID.Add(P.second);
   }
 };
-} // End of namespace llvm.
+} // End of namespace llvm_ks.
 
 #endif

--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -56,7 +56,7 @@
 #include <string>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief An opaque object representing a hash code.
 ///
@@ -67,8 +67,8 @@ namespace llvm {
 ///
 /// In order to obtain the hash_code for an object 'x':
 /// \code
-///   using llvm::hash_value;
-///   llvm::hash_code code = hash_value(x);
+///   using llvm_ks::hash_value;
+///   llvm_ks::hash_code code = hash_value(x);
 /// \endcode
 class hash_code {
   size_t value;
@@ -314,7 +314,7 @@ struct hash_state {
 
 /// \brief A global, fixed seed-override variable.
 ///
-/// This variable can be set using the \see llvm::set_fixed_execution_seed
+/// This variable can be set using the \see llvm_ks::set_fixed_execution_seed
 /// function. See that function for details. Do not, under any circumstances,
 /// set or read this variable.
 extern size_t fixed_seed_override;
@@ -373,7 +373,7 @@ get_hashable_data(const T &value) {
 template <typename T>
 typename std::enable_if<!is_hashable_data<T>::value, size_t>::type
 get_hashable_data(const T &value) {
-  using ::llvm::hash_value;
+  using ::llvm_ks::hash_value;
   return hash_value(value);
 }
 
@@ -479,7 +479,7 @@ hash_combine_range_impl(ValueT *first, ValueT *last) {
 /// a sequence of bytes.
 template <typename InputIteratorT>
 hash_code hash_combine_range(InputIteratorT first, InputIteratorT last) {
-  return ::llvm::hashing::detail::hash_combine_range_impl(first, last);
+  return ::llvm_ks::hashing::detail::hash_combine_range_impl(first, last);
 }
 
 
@@ -602,7 +602,7 @@ public:
 /// *not* call this routine, they should instead call 'hash_value'.
 template <typename ...Ts> hash_code hash_combine(const Ts &...args) {
   // Recursively hash each argument using a helper class.
-  ::llvm::hashing::detail::hash_combine_recursive_helper helper;
+  ::llvm_ks::hashing::detail::hash_combine_recursive_helper helper;
   return helper.combine(0, helper.buffer, helper.buffer + 64, args...);
 }
 
@@ -632,13 +632,13 @@ inline hash_code hash_integer_value(uint64_t value) {
 template <typename T>
 typename std::enable_if<is_integral_or_enum<T>::value, hash_code>::type
 hash_value(T value) {
-  return ::llvm::hashing::detail::hash_integer_value(value);
+  return ::llvm_ks::hashing::detail::hash_integer_value(value);
 }
 
 // Declared and documented above, but defined here so that any of the hashing
 // infrastructure is available.
 template <typename T> hash_code hash_value(const T *ptr) {
-  return ::llvm::hashing::detail::hash_integer_value(
+  return ::llvm_ks::hashing::detail::hash_integer_value(
     reinterpret_cast<uintptr_t>(ptr));
 }
 
@@ -656,6 +656,6 @@ hash_code hash_value(const std::basic_string<T> &arg) {
   return hash_combine_range(arg.begin(), arg.end());
 }
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/IndexedMap.h
+++ b/llvm/include/llvm/ADT/IndexedMap.h
@@ -25,9 +25,9 @@
 #include <cassert>
 #include <functional>
 
-namespace llvm {
+namespace llvm_ks {
 
-template <typename T, typename ToIndexT = llvm::identity<unsigned> >
+template <typename T, typename ToIndexT = llvm_ks::identity<unsigned> >
   class IndexedMap {
     typedef typename ToIndexT::argument_type IndexT;
     // Prefer SmallVector with zero inline storage over std::vector. IndexedMaps

--- a/llvm/include/llvm/ADT/IntEqClasses.h
+++ b/llvm/include/llvm/ADT/IntEqClasses.h
@@ -23,7 +23,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class IntEqClasses {
   /// EC - When uncompressed, map each integer to a smaller member of its

--- a/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
+++ b/llvm/include/llvm/ADT/IntrusiveRefCntPtr.h
@@ -25,7 +25,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace llvm {
+namespace llvm_ks {
 
   template <class T>
   class IntrusiveRefCntPtr;
@@ -88,7 +88,7 @@ namespace llvm {
     static void release(T *obj) { obj->Release(); }
   };
 
-/// \brief A thread-safe version of \c llvm::RefCountedBase.
+/// \brief A thread-safe version of \c llvm_ks::RefCountedBase.
 ///
 /// A generic base class for objects that wish to have their lifetimes managed
 /// using reference counts. Classes subclass \c ThreadSafeRefCountedBase to
@@ -282,6 +282,6 @@ public:
     }
   };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_ADT_INTRUSIVEREFCNTPTR_H

--- a/llvm/include/llvm/ADT/MapVector.h
+++ b/llvm/include/llvm/ADT/MapVector.h
@@ -21,13 +21,13 @@
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// This class implements a map that also provides access to all stored values
 /// in a deterministic order. The values are kept in a std::vector and the
 /// mapping is done with DenseMap from Keys to indexes in that vector.
 template<typename KeyT, typename ValueT,
-         typename MapType = llvm::DenseMap<KeyT, unsigned>,
+         typename MapType = llvm_ks::DenseMap<KeyT, unsigned>,
          typename VectorType = std::vector<std::pair<KeyT, ValueT> > >
 class MapVector {
   typedef typename VectorType::size_type size_type;
@@ -195,6 +195,6 @@ struct SmallMapVector
                 SmallVector<std::pair<KeyT, ValueT>, N>> {
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/None.h
+++ b/llvm/include/llvm/ADT/None.h
@@ -16,7 +16,7 @@
 #ifndef LLVM_ADT_NONE_H
 #define LLVM_ADT_NONE_H
 
-namespace llvm {
+namespace llvm_ks {
 /// \brief A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
 enum class NoneType { None };

--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -23,7 +23,7 @@
 #include <new>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 
 template<typename T>
 class Optional {

--- a/llvm/include/llvm/ADT/PointerIntPair.h
+++ b/llvm/include/llvm/ADT/PointerIntPair.h
@@ -19,7 +19,7 @@
 #include <cassert>
 #include <limits>
 
-namespace llvm {
+namespace llvm_ks {
 
 template <typename T> struct DenseMapInfo;
 
@@ -219,5 +219,5 @@ public:
   enum { NumLowBitsAvailable = PtrTraits::NumLowBitsAvailable - IntBits };
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif

--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -19,7 +19,7 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 template <typename T> struct PointerUnionTypeSelectorReturn {
   typedef T Return;
@@ -117,8 +117,8 @@ public:
 
   /// Test if the Union currently holds the type matching T.
   template <typename T> int is() const {
-    typedef typename ::llvm::PointerUnionTypeSelector<
-        PT1, T, IsPT1, ::llvm::PointerUnionTypeSelector<
+    typedef typename ::llvm_ks::PointerUnionTypeSelector<
+        PT1, T, IsPT1, ::llvm_ks::PointerUnionTypeSelector<
                            PT2, T, IsPT2, UNION_DOESNT_CONTAIN_TYPE<T>>>::Return
         Ty;
     int TyNo = Ty::Num;
@@ -263,9 +263,9 @@ public:
   /// Test if the Union currently holds the type matching T.
   template <typename T> int is() const {
     // If T is PT1/PT2 choose IsInnerUnion otherwise choose IsPT3.
-    typedef typename ::llvm::PointerUnionTypeSelector<
+    typedef typename ::llvm_ks::PointerUnionTypeSelector<
         PT1, T, IsInnerUnion,
-        ::llvm::PointerUnionTypeSelector<PT2, T, IsInnerUnion, IsPT3>>::Return
+        ::llvm_ks::PointerUnionTypeSelector<PT2, T, IsInnerUnion, IsPT3>>::Return
         Ty;
     return Ty(Val).template is<T>();
   }
@@ -276,9 +276,9 @@ public:
   template <typename T> T get() const {
     assert(is<T>() && "Invalid accessor called");
     // If T is PT1/PT2 choose IsInnerUnion otherwise choose IsPT3.
-    typedef typename ::llvm::PointerUnionTypeSelector<
+    typedef typename ::llvm_ks::PointerUnionTypeSelector<
         PT1, T, IsInnerUnion,
-        ::llvm::PointerUnionTypeSelector<PT2, T, IsInnerUnion, IsPT3>>::Return
+        ::llvm_ks::PointerUnionTypeSelector<PT2, T, IsInnerUnion, IsPT3>>::Return
         Ty;
     return Ty(Val).template get<T>();
   }
@@ -367,8 +367,8 @@ public:
   /// Test if the Union currently holds the type matching T.
   template <typename T> int is() const {
     // If T is PT1/PT2 choose InnerUnion1 otherwise choose InnerUnion2.
-    typedef typename ::llvm::PointerUnionTypeSelector<
-        PT1, T, InnerUnion1, ::llvm::PointerUnionTypeSelector<
+    typedef typename ::llvm_ks::PointerUnionTypeSelector<
+        PT1, T, InnerUnion1, ::llvm_ks::PointerUnionTypeSelector<
                                  PT2, T, InnerUnion1, InnerUnion2>>::Return Ty;
     return Val.template is<Ty>() && Val.template get<Ty>().template is<T>();
   }
@@ -379,8 +379,8 @@ public:
   template <typename T> T get() const {
     assert(is<T>() && "Invalid accessor called");
     // If T is PT1/PT2 choose InnerUnion1 otherwise choose InnerUnion2.
-    typedef typename ::llvm::PointerUnionTypeSelector<
-        PT1, T, InnerUnion1, ::llvm::PointerUnionTypeSelector<
+    typedef typename ::llvm_ks::PointerUnionTypeSelector<
+        PT1, T, InnerUnion1, ::llvm_ks::PointerUnionTypeSelector<
                                  PT2, T, InnerUnion1, InnerUnion2>>::Return Ty;
     return Val.template get<Ty>().template get<T>();
   }

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -27,7 +27,7 @@
 #include <memory>
 #include <utility> // for std::pair
 
-namespace llvm {
+namespace llvm_ks {
 
 //===----------------------------------------------------------------------===//
 //     Extra additions to <functional>
@@ -225,10 +225,10 @@ template <typename ContainerTy>
 auto reverse(
     ContainerTy &&C,
     typename std::enable_if<!has_rbegin<ContainerTy>::value>::type * = nullptr)
-    -> decltype(make_range(llvm::make_reverse_iterator(std::end(C)),
-                           llvm::make_reverse_iterator(std::begin(C)))) {
-  return make_range(llvm::make_reverse_iterator(std::end(C)),
-                    llvm::make_reverse_iterator(std::begin(C)));
+    -> decltype(make_range(llvm_ks::make_reverse_iterator(std::end(C)),
+                           llvm_ks::make_reverse_iterator(std::begin(C)))) {
+  return make_range(llvm_ks::make_reverse_iterator(std::end(C)),
+                    llvm_ks::make_reverse_iterator(std::begin(C)));
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -26,7 +26,7 @@
 #include <cassert>
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief A vector that has set insertion semantics.
 ///

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -25,7 +25,7 @@
 #include <iterator>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 
 class SmallPtrSetIteratorImpl;
 
@@ -376,7 +376,7 @@ public:
 namespace std {
   /// Implement std::swap in terms of SmallPtrSet swap.
   template<class T, unsigned N>
-  inline void swap(llvm::SmallPtrSet<T, N> &LHS, llvm::SmallPtrSet<T, N> &RHS) {
+  inline void swap(llvm_ks::SmallPtrSet<T, N> &LHS, llvm_ks::SmallPtrSet<T, N> &RHS) {
     LHS.swap(RHS);
   }
 }

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -19,7 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include <set>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// SmallSet - This maintains a set of unique values, optimizing for the case
 /// when the set is small (less than N).  In this case, the set can be
@@ -131,6 +131,6 @@ private:
 template <typename PointeeType, unsigned N>
 class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/ADT/SmallString.h
+++ b/llvm/include/llvm/ADT/SmallString.h
@@ -17,7 +17,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// SmallString - A SmallString is just a SmallVector with methods and accessors
 /// that make it work better as a string (e.g. operator+ etc).

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -28,7 +28,7 @@
 #include <iterator>
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// This is all the non-templated stuff common to all SmallVectors.
 class SmallVectorBase {
@@ -70,7 +70,7 @@ private:
   // Allocate raw space for N elements of type T.  If T has a ctor or dtor, we
   // don't want it to be automatically run, so we need to represent the space as
   // something else.  Use an array of char of sufficient alignment.
-  typedef llvm::AlignedCharArrayUnion<T> U;
+  typedef llvm_ks::AlignedCharArrayUnion<T> U;
   U FirstEl;
   // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
 
@@ -883,7 +883,7 @@ public:
   }
 
   template <typename RangeTy>
-  explicit SmallVector(const llvm::iterator_range<RangeTy> R)
+  explicit SmallVector(const llvm_ks::iterator_range<RangeTy> R)
       : SmallVectorImpl<T>(N) {
     this->append(R.begin(), R.end());
   }
@@ -939,14 +939,14 @@ namespace std {
   /// Implement std::swap in terms of SmallVector swap.
   template<typename T>
   inline void
-  swap(llvm::SmallVectorImpl<T> &LHS, llvm::SmallVectorImpl<T> &RHS) {
+  swap(llvm_ks::SmallVectorImpl<T> &LHS, llvm_ks::SmallVectorImpl<T> &RHS) {
     LHS.swap(RHS);
   }
 
   /// Implement std::swap in terms of SmallVector swap.
   template<typename T, unsigned N>
   inline void
-  swap(llvm::SmallVector<T, N> &LHS, llvm::SmallVector<T, N> &RHS) {
+  swap(llvm_ks::SmallVector<T, N> &LHS, llvm_ks::SmallVector<T, N> &RHS) {
     LHS.swap(RHS);
   }
 }

--- a/llvm/include/llvm/ADT/StringExtras.h
+++ b/llvm/include/llvm/ADT/StringExtras.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <iterator>
 
-namespace llvm {
+namespace llvm_ks {
 template<typename T> class SmallVectorImpl;
 
 /// hexdigit - Return the hexadecimal character for the

--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
   template<typename ValueT>
   class StringMapConstIterator;
   template<typename ValueT>

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
   template <typename T>
   class SmallVectorImpl;
   class APInt;

--- a/llvm/include/llvm/ADT/StringSet.h
+++ b/llvm/include/llvm/ADT/StringSet.h
@@ -16,12 +16,12 @@
 
 #include "llvm/ADT/StringMap.h"
 
-namespace llvm {
+namespace llvm_ks {
 
   /// StringSet - A wrapper for StringMap that provides set-like functionality.
-  template <class AllocatorTy = llvm::MallocAllocator>
-  class StringSet : public llvm::StringMap<char, AllocatorTy> {
-    typedef llvm::StringMap<char, AllocatorTy> base;
+  template <class AllocatorTy = llvm_ks::MallocAllocator>
+  class StringSet : public llvm_ks::StringMap<char, AllocatorTy> {
+    typedef llvm_ks::StringMap<char, AllocatorTy> base;
   public:
     StringSet() = default;
     StringSet(std::initializer_list<StringRef> S) {

--- a/llvm/include/llvm/ADT/StringSwitch.h
+++ b/llvm/include/llvm/ADT/StringSwitch.h
@@ -18,7 +18,7 @@
 #include <cassert>
 #include <cstring>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief A switch()-like statement whose cases are string literals.
 ///
@@ -161,6 +161,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_ADT_STRINGSWITCH_H

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -18,7 +18,7 @@
 #undef mips
 #undef sparc
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Triple - Helper class for working with autoconf configuration names. For
 /// historical reasons, we also call these 'triples' (they used to contain
@@ -611,7 +611,7 @@ public:
   ///
   /// \returns A new triple with a 32-bit architecture or an unknown
   ///          architecture if no such variant can be found.
-  llvm::Triple get32BitArchVariant() const;
+  llvm_ks::Triple get32BitArchVariant() const;
 
   /// Form a triple with a 64-bit variant of the current architecture.
   ///
@@ -619,7 +619,7 @@ public:
   ///
   /// \returns A new triple with a 64-bit architecture or an unknown
   ///          architecture if no such variant can be found.
-  llvm::Triple get64BitArchVariant() const;
+  llvm_ks::Triple get64BitArchVariant() const;
 
   /// Form a triple with a big endian variant of the current architecture.
   ///
@@ -627,7 +627,7 @@ public:
   ///
   /// \returns A new triple with a big endian architecture or an unknown
   ///          architecture if no such variant can be found.
-  llvm::Triple getBigEndianArchVariant() const;
+  llvm_ks::Triple getBigEndianArchVariant() const;
 
   /// Form a triple with a little endian variant of the current architecture.
   ///
@@ -635,7 +635,7 @@ public:
   ///
   /// \returns A new triple with a little endian architecture or an unknown
   ///          architecture if no such variant can be found.
-  llvm::Triple getLittleEndianArchVariant() const;
+  llvm_ks::Triple getLittleEndianArchVariant() const;
 
   /// Get the (LLVM) name of the minimum ARM CPU for the arch we are targeting.
   ///

--- a/llvm/include/llvm/ADT/Twine.h
+++ b/llvm/include/llvm/ADT/Twine.h
@@ -17,7 +17,7 @@
 #include <cassert>
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
   class raw_ostream;
 
   /// Twine - A lightweight data structure for efficiently representing the

--- a/llvm/include/llvm/ADT/edit_distance.h
+++ b/llvm/include/llvm/ADT/edit_distance.h
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief Determine the edit distance between two sequences.
 ///

--- a/llvm/include/llvm/ADT/ilist.h
+++ b/llvm/include/llvm/ADT/ilist.h
@@ -44,7 +44,7 @@
 #include <cstddef>
 #include <iterator>
 
-namespace llvm {
+namespace llvm_ks {
 
 template<typename NodeTy, typename Traits> class iplist;
 template<typename NodeTy> class ilist_iterator;
@@ -792,7 +792,7 @@ struct ilist : public iplist<NodeTy> {
 namespace std {
   // Ensure that swap uses the fast list swap...
   template<class Ty>
-  void swap(llvm::iplist<Ty> &Left, llvm::iplist<Ty> &Right) {
+  void swap(llvm_ks::iplist<Ty> &Left, llvm_ks::iplist<Ty> &Right) {
     Left.swap(Right);
   }
 }  // End 'std' extensions...

--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -15,7 +15,7 @@
 #ifndef LLVM_ADT_ILIST_NODE_H
 #define LLVM_ADT_ILIST_NODE_H
 
-namespace llvm {
+namespace llvm_ks {
 
 template<typename NodeTy>
 struct ilist_traits;

--- a/llvm/include/llvm/ADT/iterator.h
+++ b/llvm/include/llvm/ADT/iterator.h
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <iterator>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief CRTP base class which implements the entire standard iterator facade
 /// in terms of a minimal subset of the interface.

--- a/llvm/include/llvm/ADT/iterator_range.h
+++ b/llvm/include/llvm/ADT/iterator_range.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <iterator>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief A range adaptor for a pair of iterators.
 ///

--- a/llvm/include/llvm/AsmParser/Parser.h
+++ b/llvm/include/llvm/AsmParser/Parser.h
@@ -16,7 +16,7 @@
 
 #include "llvm/Support/MemoryBuffer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class Constant;
 class LLVMContext;

--- a/llvm/include/llvm/MC/ConstantPools.h
+++ b/llvm/include/llvm/MC/ConstantPools.h
@@ -19,7 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/SMLoc.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class MCExpr;
 class MCSection;
@@ -88,6 +88,6 @@ private:
   ConstantPool *getConstantPool(MCSection *Section);
   ConstantPool &getOrCreateConstantPool(MCSection *Section);
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmLayout;
 class MCAssembler;
 class MCELFObjectTargetWriter;

--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCExpr;
 class MCSection;
 class MCStreamer;

--- a/llvm/include/llvm/MC/MCAsmInfoCOFF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoCOFF.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCAsmInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
   class MCAsmInfoCOFF : public MCAsmInfo {
   protected:
     explicit MCAsmInfoCOFF();

--- a/llvm/include/llvm/MC/MCAsmInfoDarwin.h
+++ b/llvm/include/llvm/MC/MCAsmInfoDarwin.h
@@ -17,7 +17,7 @@
 
 #include "llvm/MC/MCAsmInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
   class MCAsmInfoDarwin : public MCAsmInfo {
   public:
     explicit MCAsmInfoDarwin();

--- a/llvm/include/llvm/MC/MCAsmInfoELF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoELF.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCAsmInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfoELF : public MCAsmInfo {
   MCSection *getNonexecutableStackSection(MCContext &Ctx) const final;
 

--- a/llvm/include/llvm/MC/MCAsmLayout.h
+++ b/llvm/include/llvm/MC/MCAsmLayout.h
@@ -13,7 +13,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAssembler;
 class MCFragment;
 class MCSection;
@@ -30,7 +30,7 @@ class MCAsmLayout {
   MCAssembler &Assembler;
 
   /// List of sections in layout order.
-  llvm::SmallVector<MCSection *, 16> SectionOrder;
+  llvm_ks::SmallVector<MCSection *, 16> SectionOrder;
 
   /// The last fragment which was laid out, or 0 if nothing has been laid
   /// out. Fragments are always laid out in order, so all fragments with a
@@ -63,8 +63,8 @@ public:
   /// \name Section Access (in layout order)
   /// @{
 
-  llvm::SmallVectorImpl<MCSection *> &getSectionOrder() { return SectionOrder; }
-  const llvm::SmallVectorImpl<MCSection *> &getSectionOrder() const {
+  llvm_ks::SmallVectorImpl<MCSection *> &getSectionOrder() { return SectionOrder; }
+  const llvm_ks::SmallVectorImpl<MCSection *> &getSectionOrder() const {
     return SectionOrder;
   }
 
@@ -102,6 +102,6 @@ public:
   /// @}
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -25,7 +25,7 @@
 
 #include "keystone/keystone.h"
 
-namespace llvm {
+namespace llvm_ks {
 class raw_ostream;
 class MCAsmLayout;
 class MCAssembler;
@@ -430,6 +430,6 @@ public:
 uint64_t computeBundlePadding(const MCAssembler &Assembler, const MCFragment *F,
                               uint64_t FOffset, uint64_t FSize);
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCCodeEmitter.h
+++ b/llvm/include/llvm/MC/MCCodeEmitter.h
@@ -12,7 +12,7 @@
 
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCFixup;
 class MCInst;
 class MCSubtargetInfo;

--- a/llvm/include/llvm/MC/MCCodeView.h
+++ b/llvm/include/llvm/MC/MCCodeView.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class MCObjectStreamer;
 class MCStreamer;
@@ -180,5 +180,5 @@ private:
   std::vector<MCCVLineEntry> MCCVLines;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif

--- a/llvm/include/llvm/MC/MCContext.h
+++ b/llvm/include/llvm/MC/MCContext.h
@@ -27,7 +27,7 @@
 #include <tuple>
 #include <vector> // FIXME: Shouldn't be needed.
 
-namespace llvm {
+namespace llvm_ks {
   class MCAsmInfo;
   class MCExpr;
   class MCSection;
@@ -566,7 +566,7 @@ namespace llvm {
                                                   const Twine &Msg);
   };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 // operator new and delete aren't allowed inside namespaces.
 // The throw specifications are mandated by the standard.
@@ -592,7 +592,7 @@ namespace llvm {
 /// \param Alignment The alignment of the allocated memory (if the underlying
 ///                  allocator supports it).
 /// \return The allocated memory. Could be NULL.
-inline void *operator new(size_t Bytes, llvm::MCContext &C,
+inline void *operator new(size_t Bytes, llvm_ks::MCContext &C,
                           size_t Alignment = 8) LLVM_NOEXCEPT {
   return C.allocate(Bytes, Alignment);
 }
@@ -602,7 +602,7 @@ inline void *operator new(size_t Bytes, llvm::MCContext &C,
 /// invoking it directly; see the new operator for more details. This operator
 /// is called implicitly by the compiler if a placement new expression using
 /// the MCContext throws in the object constructor.
-inline void operator delete(void *Ptr, llvm::MCContext &C,
+inline void operator delete(void *Ptr, llvm_ks::MCContext &C,
                             size_t) LLVM_NOEXCEPT {
   C.deallocate(Ptr);
 }
@@ -626,7 +626,7 @@ inline void operator delete(void *Ptr, llvm::MCContext &C,
 /// \param Alignment The alignment of the allocated memory (if the underlying
 ///                  allocator supports it).
 /// \return The allocated memory. Could be NULL.
-inline void *operator new[](size_t Bytes, llvm::MCContext &C,
+inline void *operator new[](size_t Bytes, llvm_ks::MCContext &C,
                             size_t Alignment = 8) LLVM_NOEXCEPT {
   return C.allocate(Bytes, Alignment);
 }
@@ -637,7 +637,7 @@ inline void *operator new[](size_t Bytes, llvm::MCContext &C,
 /// invoking it directly; see the new[] operator for more details. This operator
 /// is called implicitly by the compiler if a placement new[] expression using
 /// the MCContext throws in the object constructor.
-inline void operator delete[](void *Ptr, llvm::MCContext &C) LLVM_NOEXCEPT {
+inline void operator delete[](void *Ptr, llvm_ks::MCContext &C) LLVM_NOEXCEPT {
   C.deallocate(Ptr);
 }
 

--- a/llvm/include/llvm/MC/MCDirectives.h
+++ b/llvm/include/llvm/MC/MCDirectives.h
@@ -14,7 +14,7 @@
 #ifndef LLVM_MC_MCDIRECTIVES_H
 #define LLVM_MC_MCDIRECTIVES_H
 
-namespace llvm {
+namespace llvm_ks {
 
 enum MCSymbolAttr {
   MCSA_Invalid = 0,    ///< Not a valid directive.
@@ -67,6 +67,6 @@ enum MCVersionMinType {
   MCVM_WatchOSVersionMin,     ///< .watchos_version_min
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -28,7 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCContext;
 class MCObjectStreamer;
@@ -518,6 +518,6 @@ public:
   static void EncodeAdvanceLoc(MCContext &Context, uint64_t AddrDelta,
                                raw_ostream &OS);
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCELFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCELFObjectWriter.h
@@ -15,7 +15,7 @@
 #include "llvm/Support/ELF.h"
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAssembler;
 class MCContext;
 class MCFixup;

--- a/llvm/include/llvm/MC/MCELFStreamer.h
+++ b/llvm/include/llvm/MC/MCELFStreamer.h
@@ -17,7 +17,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCAssembler;
 class MCCodeEmitter;
@@ -96,7 +96,7 @@ private:
 
   /// BundleGroups - The stack of fragments holding the bundle-locked
   /// instructions.
-  llvm::SmallVector<MCDataFragment *, 4> BundleGroups;
+  llvm_ks::SmallVector<MCDataFragment *, 4> BundleGroups;
 };
 
 MCELFStreamer *createARMELFStreamer(MCContext &Context, MCAsmBackend &TAB,
@@ -104,6 +104,6 @@ MCELFStreamer *createARMELFStreamer(MCContext &Context, MCAsmBackend &TAB,
                                     MCCodeEmitter *Emitter, bool RelaxAll,
                                     bool IsThumb);
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCExpr.h
+++ b/llvm/include/llvm/MC/MCExpr.h
@@ -14,7 +14,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfo;
 class MCAsmLayout;
 class MCAssembler;
@@ -569,6 +569,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCFixup.h
+++ b/llvm/include/llvm/MC/MCFixup.h
@@ -16,7 +16,7 @@
 #include "llvm/Support/SMLoc.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 class MCExpr;
 
 /// \brief Extensible enumeration to represent the type of a fixup.

--- a/llvm/include/llvm/MC/MCFixupKindInfo.h
+++ b/llvm/include/llvm/MC/MCFixupKindInfo.h
@@ -10,7 +10,7 @@
 #ifndef LLVM_MC_MCFIXUPKINDINFO_H
 #define LLVM_MC_MCFIXUPKINDINFO_H
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief Target independent information on a fixup kind.
 struct MCFixupKindInfo {

--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCInst.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCSection;
 class MCSymbol;
 class MCSubtargetInfo;
@@ -484,6 +484,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCInst.h
+++ b/llvm/include/llvm/MC/MCInst.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/SMLoc.h"
 
-namespace llvm {
+namespace llvm_ks {
 class raw_ostream;
 class MCAsmInfo;
 class MCExpr;
@@ -197,6 +197,6 @@ inline raw_ostream& operator<<(raw_ostream &OS, const MCInst &MI) {
   return OS;
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCInstBuilder.h
+++ b/llvm/include/llvm/MC/MCInstBuilder.h
@@ -17,7 +17,7 @@
 
 #include "llvm/MC/MCInst.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCInstBuilder {
   MCInst Inst;
@@ -69,6 +69,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCInstrDesc.h
+++ b/llvm/include/llvm/MC/MCInstrDesc.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
   class MCInst;
   class MCSubtargetInfo;
 
@@ -318,6 +318,6 @@ public:
 
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCInstrInfo.h
+++ b/llvm/include/llvm/MC/MCInstrInfo.h
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCInstrDesc.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 //---------------------------------------------------------------------------
 /// \brief Interface to description of machine instruction set.

--- a/llvm/include/llvm/MC/MCInstrItineraries.h
+++ b/llvm/include/llvm/MC/MCInstrItineraries.h
@@ -19,7 +19,7 @@
 #include "llvm/MC/MCSchedule.h"
 #include <algorithm>
 
-namespace llvm {
+namespace llvm_ks {
 
 //===----------------------------------------------------------------------===//
 /// These values represent a non-pipelined step in

--- a/llvm/include/llvm/MC/MCLabel.h
+++ b/llvm/include/llvm/MC/MCLabel.h
@@ -16,7 +16,7 @@
 
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class raw_ostream;
 
@@ -52,6 +52,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, const MCLabel &Label) {
   Label.print(OS);
   return OS;
 }
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCLinkerOptimizationHint.h
+++ b/llvm/include/llvm/MC/MCLinkerOptimizationHint.h
@@ -22,7 +22,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 // Forward declarations.
 class MCAsmLayout;
@@ -148,6 +148,6 @@ public:
 typedef MCLOHDirective::LOHArgs MCLOHArgs;
 typedef MCLOHContainer::LOHDirectives MCLOHDirectives;
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCObjectFileInfo.h
+++ b/llvm/include/llvm/MC/MCObjectFileInfo.h
@@ -16,7 +16,7 @@
 
 #include "llvm/ADT/Triple.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class MCSection;
 
@@ -350,6 +350,6 @@ public:
   const Triple &getTargetTriple() const { return TT; }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -15,7 +15,7 @@
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAssembler;
 class MCCodeEmitter;
 class MCSubtargetInfo;
@@ -153,6 +153,6 @@ public:
   uint64_t getCurrentFragmentSize() override;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -17,7 +17,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmLayout;
 class MCAssembler;
 class MCFixup;

--- a/llvm/include/llvm/MC/MCParser/AsmCond.h
+++ b/llvm/include/llvm/MC/MCParser/AsmCond.h
@@ -10,7 +10,7 @@
 #ifndef LLVM_MC_MCPARSER_ASMCOND_H
 #define LLVM_MC_MCPARSER_ASMCOND_H
 
-namespace llvm {
+namespace llvm_ks {
 
 /// AsmCond - Class to support conditional assembly
 ///
@@ -35,6 +35,6 @@ public:
   AsmCond() : TheCond(NoCond), CondMet(false), Ignore(false) {}
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class MemoryBuffer;
 class MCAsmInfo;
 
@@ -70,6 +70,6 @@ private:
   AsmToken LexHexFloatLiteral(bool NoIntDigits);
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCParser/MCAsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmLexer.h
@@ -16,7 +16,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/SMLoc.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Target independent representation for an assembler token.
 class AsmToken {

--- a/llvm/include/llvm/MC/MCParser/MCAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParser.h
@@ -15,7 +15,7 @@
 #include "llvm/MC/MCParser/AsmLexer.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfo;
 class MCAsmLexer;
 class MCAsmParserExtension;

--- a/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParserExtension.h
@@ -14,7 +14,7 @@
 #include "llvm/MC/MCParser/MCAsmParser.h"
 #include "llvm/Support/SMLoc.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Twine;
 
 /// \brief Generic interface for extending the MCAsmParser,

--- a/llvm/include/llvm/MC/MCParser/MCAsmParserUtils.h
+++ b/llvm/include/llvm/MC/MCParser/MCAsmParserUtils.h
@@ -10,7 +10,7 @@
 #ifndef LLVM_MC_MCPARSER_MCASMPARSERUTILS_H
 #define LLVM_MC_MCPARSER_MCASMPARSERUTILS_H
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCAsmParser;
 class MCExpr;
@@ -28,6 +28,6 @@ bool parseAssignmentExpression(StringRef Name, bool allow_redef,
                                const MCExpr *&Value);
 
 } // namespace MCParserUtils
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCParser/MCParsedAsmOperand.h
+++ b/llvm/include/llvm/MC/MCParser/MCParsedAsmOperand.h
@@ -14,7 +14,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SMLoc.h"
 
-namespace llvm {
+namespace llvm_ks {
 class raw_ostream;
 
 /// MCParsedAsmOperand - This abstract class represents a source-level assembly
@@ -93,6 +93,6 @@ inline raw_ostream& operator<<(raw_ostream &OS, const MCParsedAsmOperand &MO) {
   return OS;
 }
 
-} // end namespace llvm.
+} // end namespace llvm_ks.
 
 #endif

--- a/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
+++ b/llvm/include/llvm/MC/MCParser/MCTargetAsmParser.h
@@ -15,7 +15,7 @@
 #include "llvm/MC/MCTargetOptions.h"
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 class AsmToken;
 class MCInst;
 class MCParsedAsmOperand;

--- a/llvm/include/llvm/MC/MCRegisterInfo.h
+++ b/llvm/include/llvm/MC/MCRegisterInfo.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// An unsigned integer type large enough to represent all physical registers,
 /// but not necessarily virtual registers.

--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 struct InstrItinerary;
 

--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -22,7 +22,7 @@
 #include "llvm/MC/SectionKind.h"
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfo;
 class MCAssembler;
 class MCContext;
@@ -198,6 +198,6 @@ public:
   virtual bool isVirtualSection() const = 0;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCSectionCOFF.h
+++ b/llvm/include/llvm/MC/MCSectionCOFF.h
@@ -17,7 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCSection.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCSymbol;
 
 /// This represents a section on Windows
@@ -74,6 +74,6 @@ public:
   static bool classof(const MCSection *S) { return S->getVariant() == SV_COFF; }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCSectionELF.h
+++ b/llvm/include/llvm/MC/MCSectionELF.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/ELF.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCSymbol;
 
@@ -92,6 +92,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCSectionMachO.h
+++ b/llvm/include/llvm/MC/MCSectionMachO.h
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCSection.h"
 #include "llvm/Support/MachO.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// This represents a section on a Mach-O system (used by Mac OS X).  On a Mac
 /// system, these are also described in /usr/include/mach-o/loader.h.
@@ -86,6 +86,6 @@ public:
   }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -26,7 +26,7 @@
 
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;
@@ -774,6 +774,6 @@ MCStreamer *createAsmStreamer(MCContext &Ctx,
                               std::unique_ptr<formatted_raw_ostream> OS,
                               MCCodeEmitter *CE,
                               MCAsmBackend *TAB);
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCSubtargetInfo.h
+++ b/llvm/include/llvm/MC/MCSubtargetInfo.h
@@ -19,7 +19,7 @@
 #include "llvm/MC/SubtargetFeature.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 
 class StringRef;
 

--- a/llvm/include/llvm/MC/MCSymbol.h
+++ b/llvm/include/llvm/MC/MCSymbol.h
@@ -20,7 +20,7 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfo;
 class MCExpr;
 class MCSymbol;
@@ -416,6 +416,6 @@ inline raw_ostream &operator<<(raw_ostream &OS, const MCSymbol &Sym) {
   Sym.print(OS, nullptr);
   return OS;
 }
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCSymbolCOFF.h
+++ b/llvm/include/llvm/MC/MCSymbolCOFF.h
@@ -11,7 +11,7 @@
 
 #include "llvm/MC/MCSymbol.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCSymbolCOFF : public MCSymbol {
 
   /// This corresponds to the e_type field of the COFF symbol.

--- a/llvm/include/llvm/MC/MCSymbolELF.h
+++ b/llvm/include/llvm/MC/MCSymbolELF.h
@@ -11,7 +11,7 @@
 
 #include "llvm/MC/MCSymbol.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCSymbolELF : public MCSymbol {
   /// An expression describing how to calculate the size of a symbol. If a
   /// symbol has no size this field will be NULL.

--- a/llvm/include/llvm/MC/MCSymbolMachO.h
+++ b/llvm/include/llvm/MC/MCSymbolMachO.h
@@ -11,7 +11,7 @@
 
 #include "llvm/MC/MCSymbol.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCSymbolMachO : public MCSymbol {
   /// \brief We store the value for the 'desc' symbol field in the
   /// lowest 16 bits of the implementation defined flags.

--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -12,7 +12,7 @@
 
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 
 class StringRef;
 
@@ -36,6 +36,6 @@ public:
   MCTargetOptions();
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
+++ b/llvm/include/llvm/MC/MCTargetOptionsCommandFlags.h
@@ -17,7 +17,7 @@
 
 #include "llvm/MC/MCTargetOptions.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 bool RelaxAll;
 

--- a/llvm/include/llvm/MC/MCValue.h
+++ b/llvm/include/llvm/MC/MCValue.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmInfo;
 class raw_ostream;
 
@@ -81,6 +81,6 @@ public:
 
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCWin64EH.h
+++ b/llvm/include/llvm/MC/MCWin64EH.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/Win64EH.h"
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCStreamer;
 class MCSymbol;
 
@@ -58,6 +58,6 @@ public:
   void EmitUnwindInfo(MCStreamer &Streamer, WinEH::FrameInfo *FI) const override;
 };
 }
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/MCWinEH.h
+++ b/llvm/include/llvm/MC/MCWinEH.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class MCSection;
 class MCStreamer;

--- a/llvm/include/llvm/MC/MachineLocation.h
+++ b/llvm/include/llvm/MC/MachineLocation.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
   class MCSymbol;
 
 class MachineLocation {

--- a/llvm/include/llvm/MC/SectionKind.h
+++ b/llvm/include/llvm/MC/SectionKind.h
@@ -10,7 +10,7 @@
 #ifndef LLVM_MC_SECTIONKIND_H
 #define LLVM_MC_SECTIONKIND_H
 
-namespace llvm {
+namespace llvm_ks {
 
 /// SectionKind - This is a simple POD value that classifies the properties of
 /// a section.  A section is classified into the deepest possible
@@ -190,6 +190,6 @@ public:
   static SectionKind getReadOnlyWithRel() { return get(ReadOnlyWithRel); }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/MC/StringTableBuilder.h
+++ b/llvm/include/llvm/MC/StringTableBuilder.h
@@ -14,7 +14,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief Utility for building string tables with deduplicated suffixes.
 class StringTableBuilder {

--- a/llvm/include/llvm/MC/SubtargetFeature.h
+++ b/llvm/include/llvm/MC/SubtargetFeature.h
@@ -23,7 +23,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <bitset>
 
-namespace llvm {
+namespace llvm_ks {
   class raw_ostream;
   class StringRef;
 
@@ -126,6 +126,6 @@ public:
   void getDefaultSubtargetFeatures(const Triple& Triple);
 };
 
-} // End namespace llvm
+} // End namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Object/Binary.h
+++ b/llvm/include/llvm/Object/Binary.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class LLVMContext;
 class StringRef;

--- a/llvm/include/llvm/Object/COFF.h
+++ b/llvm/include/llvm/Object/COFF.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorOr.h"
 
-namespace llvm {
+namespace llvm_ks {
 template <typename T> class ArrayRef;
 
 namespace object {
@@ -910,6 +910,6 @@ private:
 };
 
 } // end namespace object
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -18,7 +18,7 @@
 #include "llvm/Object/ELFTypes.h"
 #include "llvm/Support/MemoryBuffer.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 StringRef getELFRelocationTypeName(uint32_t Machine, uint32_t Type);
@@ -537,6 +537,6 @@ static inline unsigned elf_hash(StringRef &symbolName) {
   return h;
 }
 } // end namespace object
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -32,7 +32,7 @@
 #include <limits>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 class elf_symbol_iterator;

--- a/llvm/include/llvm/Object/ELFTypes.h
+++ b/llvm/include/llvm/Object/ELFTypes.h
@@ -16,7 +16,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/ErrorOr.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 using support::endianness;
@@ -512,7 +512,7 @@ struct Elf_GnuHash_Impl {
 template <class ELFT>
 struct Elf_Mips_RegInfo;
 
-template <llvm::support::endianness TargetEndianness>
+template <llvm_ks::support::endianness TargetEndianness>
 struct Elf_Mips_RegInfo<ELFType<TargetEndianness, false>> {
   LLVM_ELF_IMPORT_TYPES(TargetEndianness, false)
   Elf_Word ri_gprmask;     // bit-mask of used general registers
@@ -520,7 +520,7 @@ struct Elf_Mips_RegInfo<ELFType<TargetEndianness, false>> {
   Elf_Addr ri_gp_value;    // gp register value
 };
 
-template <llvm::support::endianness TargetEndianness>
+template <llvm_ks::support::endianness TargetEndianness>
 struct Elf_Mips_RegInfo<ELFType<TargetEndianness, true>> {
   LLVM_ELF_IMPORT_TYPES(TargetEndianness, true)
   Elf_Word ri_gprmask;     // bit-mask of used general registers
@@ -539,7 +539,7 @@ template <class ELFT> struct Elf_Mips_Options {
   Elf_Word info;    // Kind-specific information
 
   const Elf_Mips_RegInfo<ELFT> &getRegInfo() const {
-    assert(kind == llvm::ELF::ODK_REGINFO);
+    assert(kind == llvm_ks::ELF::ODK_REGINFO);
     return *reinterpret_cast<const Elf_Mips_RegInfo<ELFT> *>(
                (const uint8_t *)this + sizeof(Elf_Mips_Options));
   }
@@ -562,6 +562,6 @@ template <class ELFT> struct Elf_Mips_ABIFlags {
 };
 
 } // end namespace object.
-} // end namespace llvm.
+} // end namespace llvm_ks.
 
 #endif

--- a/llvm/include/llvm/Object/Error.h
+++ b/llvm/include/llvm/Object/Error.h
@@ -16,7 +16,7 @@
 
 #include <system_error>
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 const std::error_category &object_category();
@@ -42,11 +42,11 @@ inline std::error_code make_error_code(object_error e) {
 
 } // end namespace object.
 
-} // end namespace llvm.
+} // end namespace llvm_ks.
 
 namespace std {
 template <>
-struct is_error_code_enum<llvm::object::object_error> : std::true_type {};
+struct is_error_code_enum<llvm_ks::object::object_error> : std::true_type {};
 }
 
 #endif

--- a/llvm/include/llvm/Object/MachO.h
+++ b/llvm/include/llvm/Object/MachO.h
@@ -21,7 +21,7 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/MachO.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 /// DiceRef - This is a value type class that represents a single
@@ -52,7 +52,7 @@ typedef content_iterator<DiceRef> dice_iterator;
 /// ExportEntry encapsulates the current-state-of-the-walk used when doing a
 /// non-recursive walk of the trie data structure.  This allows you to iterate
 /// across all exported symbols using:
-///      for (const llvm::object::ExportEntry &AnExport : Obj->exports()) {
+///      for (const llvm_ks::object::ExportEntry &AnExport : Obj->exports()) {
 ///      }
 class ExportEntry {
 public:
@@ -103,7 +103,7 @@ typedef content_iterator<ExportEntry> export_iterator;
 /// MachORebaseEntry encapsulates the current state in the decompression of
 /// rebasing opcodes. This allows you to iterate through the compressed table of
 /// rebasing using:
-///    for (const llvm::object::MachORebaseEntry &Entry : Obj->rebaseTable()) {
+///    for (const llvm_ks::object::MachORebaseEntry &Entry : Obj->rebaseTable()) {
 ///    }
 class MachORebaseEntry {
 public:
@@ -139,7 +139,7 @@ typedef content_iterator<MachORebaseEntry> rebase_iterator;
 /// MachOBindEntry encapsulates the current state in the decompression of
 /// binding opcodes. This allows you to iterate through the compressed table of
 /// bindings using:
-///    for (const llvm::object::MachOBindEntry &Entry : Obj->bindTable()) {
+///    for (const llvm_ks::object::MachOBindEntry &Entry : Obj->bindTable()) {
 ///    }
 class MachOBindEntry {
 public:

--- a/llvm/include/llvm/Object/ObjectFile.h
+++ b/llvm/include/llvm/Object/ObjectFile.h
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 class ObjectFile;
@@ -453,6 +453,6 @@ inline const ObjectFile *RelocationRef::getObject() const {
 
 
 } // end namespace object
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Object/SymbolicFile.h
+++ b/llvm/include/llvm/Object/SymbolicFile.h
@@ -17,7 +17,7 @@
 #include "llvm/Object/Binary.h"
 #include "llvm/Support/Format.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace object {
 
 union DataRefImpl {

--- a/llvm/include/llvm/Support/ARMBuildAttributes.h
+++ b/llvm/include/llvm/Support/ARMBuildAttributes.h
@@ -19,7 +19,7 @@
 #ifndef LLVM_SUPPORT_ARMBUILDATTRIBUTES_H
 #define LLVM_SUPPORT_ARMBUILDATTRIBUTES_H
 
-namespace llvm {
+namespace llvm_ks {
 class StringRef;
 
 namespace ARMBuildAttrs {
@@ -228,6 +228,6 @@ enum {
 };
 
 } // namespace ARMBuildAttrs
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/ARMEHABI.h
+++ b/llvm/include/llvm/Support/ARMEHABI.h
@@ -22,7 +22,7 @@
 #ifndef LLVM_SUPPORT_ARMEHABI_H
 #define LLVM_SUPPORT_ARMEHABI_H
 
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 namespace EHABI {
   /// ARM exception handling table entry kinds

--- a/llvm/include/llvm/Support/ARMWinEH.h
+++ b/llvm/include/llvm/Support/ARMWinEH.h
@@ -13,7 +13,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Endian.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 namespace WinEH {
 enum class RuntimeFunctionFlag {

--- a/llvm/include/llvm/Support/AlignOf.h
+++ b/llvm/include/llvm/Support/AlignOf.h
@@ -19,7 +19,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace detail {
 
@@ -71,8 +71,8 @@ template <typename T>
 struct AlignOf {
 #ifndef _MSC_VER
   // Avoid warnings from GCC like:
-  //   comparison between 'enum llvm::AlignOf<X>::<anonymous>' and 'enum
-  //   llvm::AlignOf<Y>::<anonymous>' [-Wenum-compare]
+  //   comparison between 'enum llvm_ks::AlignOf<X>::<anonymous>' and 'enum
+  //   llvm_ks::AlignOf<Y>::<anonymous>' [-Wenum-compare]
   // by using constexpr instead of enum.
   // (except on MSVC, since it doesn't support constexpr yet).
   static constexpr unsigned Alignment = static_cast<unsigned int>(
@@ -80,7 +80,7 @@ struct AlignOf {
 #else
   enum {
     Alignment = static_cast<unsigned int>(
-        sizeof(::llvm::detail::AlignmentCalcImpl<T>) - sizeof(T))
+        sizeof(::llvm_ks::detail::AlignmentCalcImpl<T>) - sizeof(T))
   };
 #endif
   enum { Alignment_GreaterEqual_2Bytes = Alignment >= 2 ? 1 : 0 };
@@ -248,12 +248,12 @@ template <typename T1,
           typename T2 = char, typename T3 = char, typename T4 = char,
           typename T5 = char, typename T6 = char, typename T7 = char,
           typename T8 = char, typename T9 = char, typename T10 = char>
-struct AlignedCharArrayUnion : llvm::AlignedCharArray<
-    AlignOf<llvm::detail::AlignerImpl<T1, T2, T3, T4, T5,
+struct AlignedCharArrayUnion : llvm_ks::AlignedCharArray<
+    AlignOf<llvm_ks::detail::AlignerImpl<T1, T2, T3, T4, T5,
                                       T6, T7, T8, T9, T10> >::Alignment,
-    sizeof(::llvm::detail::SizerImpl<T1, T2, T3, T4, T5,
+    sizeof(::llvm_ks::detail::SizerImpl<T1, T2, T3, T4, T5,
                                      T6, T7, T8, T9, T10>)> {
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_SUPPORT_ALIGNOF_H

--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -31,7 +31,7 @@
 #include <cstddef>
 #include <cstdlib>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief CRTP base class providing obvious overloads for the core \c
 /// Allocate() methods of LLVM-style allocators.
@@ -408,11 +408,11 @@ public:
   T *Allocate(size_t num = 1) { return Allocator.Allocate<T>(num); }
 };
 
-}  // end namespace llvm
+}  // end namespace llvm_ks
 
 template <typename AllocatorT, size_t SlabSize, size_t SizeThreshold>
 void *operator new(size_t Size,
-                   llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize,
+                   llvm_ks::BumpPtrAllocatorImpl<AllocatorT, SlabSize,
                                               SizeThreshold> &Allocator) {
   struct S {
     char c;
@@ -424,12 +424,12 @@ void *operator new(size_t Size,
     } x;
   };
   return Allocator.Allocate(
-      Size, std::min((size_t)llvm::NextPowerOf2(Size), offsetof(S, x)));
+      Size, std::min((size_t)llvm_ks::NextPowerOf2(Size), offsetof(S, x)));
 }
 
 template <typename AllocatorT, size_t SlabSize, size_t SizeThreshold>
 void operator delete(
-    void *, llvm::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold> &) {
+    void *, llvm_ks::BumpPtrAllocatorImpl<AllocatorT, SlabSize, SizeThreshold> &) {
 }
 
 #endif // LLVM_SUPPORT_ALLOCATOR_H

--- a/llvm/include/llvm/Support/COFF.h
+++ b/llvm/include/llvm/Support/COFF.h
@@ -27,7 +27,7 @@
 #include <cassert>
 #include <cstring>
 
-namespace llvm {
+namespace llvm_ks {
 namespace COFF {
 
   // The maximum number of sections that a COFF object can have (inclusive).
@@ -665,6 +665,6 @@ namespace COFF {
   }
 
 } // End namespace COFF.
-} // End namespace llvm.
+} // End namespace llvm_ks.
 
 #endif

--- a/llvm/include/llvm/Support/Capacity.h
+++ b/llvm/include/llvm/Support/Capacity.h
@@ -17,7 +17,7 @@
 
 #include <cstddef>
 
-namespace llvm {
+namespace llvm_ks {
 
 template <typename T>
 static inline size_t capacity_in_bytes(const T &x) {
@@ -26,7 +26,7 @@ static inline size_t capacity_in_bytes(const T &x) {
   return x.capacity() * sizeof(typename T::value_type);
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif
 

--- a/llvm/include/llvm/Support/Casting.h
+++ b/llvm/include/llvm/Support/Casting.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/type_traits.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 //===----------------------------------------------------------------------===//
 //                          isa<x> Support Templates

--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -13,7 +13,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 class DataExtractor {
   StringRef Data;
   uint8_t IsLittleEndian;
@@ -360,6 +360,6 @@ public:
   }
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -28,7 +28,7 @@
 #ifndef LLVM_SUPPORT_DEBUG_H
 #define LLVM_SUPPORT_DEBUG_H
 
-namespace llvm {
+namespace llvm_ks {
 class raw_ostream;
 
 #ifndef NDEBUG

--- a/llvm/include/llvm/Support/Dwarf.h
+++ b/llvm/include/llvm/Support/Dwarf.h
@@ -24,7 +24,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace dwarf {
 
@@ -695,6 +695,6 @@ private:
 
 } // End of namespace dwarf
 
-} // End of namespace llvm
+} // End of namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/ELF.h
+++ b/llvm/include/llvm/Support/ELF.h
@@ -24,7 +24,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <cstring>
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace ELF {
 
@@ -1302,6 +1302,6 @@ enum {
 
 } // end namespace ELF
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/SwapByteOrder.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace support {
 enum endianness {big, little, native};
 
@@ -344,6 +344,6 @@ inline void write32be(void *P, uint32_t V) { write32<big>(P, V); }
 inline void write64be(void *P, uint64_t V) { write64<big>(P, V); }
 } // end namespace endian
 } // end namespace support
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/EndianStream.h
+++ b/llvm/include/llvm/Support/EndianStream.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace support {
 
 namespace endian {
@@ -64,6 +64,6 @@ inline void Writer<big>::write<double>(double Val) {
 } // end namespace endian
 
 } // end namespace support
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/Errc.h
+++ b/llvm/include/llvm/Support/Errc.h
@@ -1,4 +1,4 @@
-//===- llvm/Support/Errc.h - Defines the llvm::errc enum --------*- C++ -*-===//
+//===- llvm/Support/Errc.h - Defines the llvm_ks::errc enum --------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -32,7 +32,7 @@
 
 #include <system_error>
 
-namespace llvm {
+namespace llvm_ks {
 enum class errc {
   argument_list_too_long = int(std::errc::argument_list_too_long),
   argument_out_of_domain = int(std::errc::argument_out_of_domain),
@@ -81,6 +81,6 @@ inline std::error_code make_error_code(errc E) {
 }
 
 namespace std {
-template <> struct is_error_code_enum<llvm::errc> : std::true_type {};
+template <> struct is_error_code_enum<llvm_ks::errc> : std::true_type {};
 }
 #endif

--- a/llvm/include/llvm/Support/Errno.h
+++ b/llvm/include/llvm/Support/Errno.h
@@ -16,7 +16,7 @@
 
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
 /// Returns a string representation of the errno value, using whatever
@@ -29,6 +29,6 @@ std::string StrError();
 std::string StrError(int errnum);
 
 }  // namespace sys
-}  // namespace llvm
+}  // namespace llvm_ks
 
 #endif  // LLVM_SYSTEM_ERRNO_H

--- a/llvm/include/llvm/Support/ErrorHandling.h
+++ b/llvm/include/llvm/Support/ErrorHandling.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/Compiler.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
   class Twine;
 
   /// An error handler callback.
@@ -96,11 +96,11 @@ LLVM_ATTRIBUTE_NORETURN void report_fatal_error(const Twine &reason,
 /// allows compilers to omit some unnecessary code.
 #ifndef NDEBUG
 #define llvm_unreachable(msg) \
-  ::llvm::llvm_unreachable_internal(msg, __FILE__, __LINE__)
+  ::llvm_ks::llvm_unreachable_internal(msg, __FILE__, __LINE__)
 #elif defined(LLVM_BUILTIN_UNREACHABLE)
 #define llvm_unreachable(msg) LLVM_BUILTIN_UNREACHABLE
 #else
-#define llvm_unreachable(msg) ::llvm::llvm_unreachable_internal()
+#define llvm_unreachable(msg) ::llvm_ks::llvm_unreachable_internal()
 #endif
 
 #endif

--- a/llvm/include/llvm/Support/ErrorOr.h
+++ b/llvm/include/llvm/Support/ErrorOr.h
@@ -22,7 +22,7 @@
 #include <system_error>
 #include <type_traits>
 
-namespace llvm {
+namespace llvm_ks {
 template<class T, class V>
 typename std::enable_if< std::is_constructible<T, V>::value
                        , typename std::remove_reference<V>::type>::type &&
@@ -292,6 +292,6 @@ typename std::enable_if<std::is_error_code_enum<E>::value ||
 operator==(const ErrorOr<T> &Err, E Code) {
   return Err.getError() == Code;
 }
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_SUPPORT_ERROROR_H

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::fs namespace. It is designed after
+// This file declares the llvm_ks::sys::fs namespace. It is designed after
 // TR2/boost filesystem (v3), but modified to remove exception handling and the
 // path class.
 //
@@ -44,7 +44,7 @@
 #include <sys/stat.h>
 #endif
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 namespace fs {
 
@@ -889,6 +889,6 @@ public:
 
 } // end namespace fs
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/Format.h
+++ b/llvm/include/llvm/Support/Format.h
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <tuple>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// This is a helper class used for handling formatted output.  It is the
 /// abstract base class of a templated derived class.
@@ -190,6 +190,6 @@ inline FormattedNumber format_decimal(int64_t N, unsigned Width) {
   return FormattedNumber(0, N, Width, false, false, false);
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/FormattedStream.h
+++ b/llvm/include/llvm/Support/FormattedStream.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// formatted_raw_ostream - A raw_ostream that wraps another one and keeps track
 /// of line and column position, allowing padding out to specific column

--- a/llvm/include/llvm/Support/Host.h
+++ b/llvm/include/llvm/Support/Host.h
@@ -26,7 +26,7 @@
 
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
 #if defined(BYTE_ORDER) && defined(BIG_ENDIAN) && BYTE_ORDER == BIG_ENDIAN

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -17,7 +17,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Utility function to encode a SLEB128 value to an output stream.
 inline void encodeSLEB128(int64_t Value, raw_ostream &OS) {
@@ -116,6 +116,6 @@ extern unsigned getULEB128Size(uint64_t Value);
 /// Utility function to get the size of the SLEB128-encoded value.
 extern unsigned getSLEB128Size(int64_t Value);
 
-}  // namespace llvm
+}  // namespace llvm_ks
 
 #endif  // LLVM_SYSTEM_LEB128_H

--- a/llvm/include/llvm/Support/MachO.h
+++ b/llvm/include/llvm/Support/MachO.h
@@ -18,12 +18,12 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Host.h"
 
-namespace llvm {
+namespace llvm_ks {
   namespace MachO {
     // Enums from <mach-o/loader.h>
     enum : uint32_t {
-      // Constants for the "magic" field in llvm::MachO::mach_header and
-      // llvm::MachO::mach_header_64
+      // Constants for the "magic" field in llvm_ks::MachO::mach_header and
+      // llvm_ks::MachO::mach_header_64
       MH_MAGIC    = 0xFEEDFACEu,
       MH_CIGAM    = 0xCEFAEDFEu,
       MH_MAGIC_64 = 0xFEEDFACFu,
@@ -33,8 +33,8 @@ namespace llvm {
     };
 
     enum HeaderFileType {
-      // Constants for the "filetype" field in llvm::MachO::mach_header and
-      // llvm::MachO::mach_header_64
+      // Constants for the "filetype" field in llvm_ks::MachO::mach_header and
+      // llvm_ks::MachO::mach_header_64
       MH_OBJECT      = 0x1u,
       MH_EXECUTE     = 0x2u,
       MH_FVMLIB      = 0x3u,
@@ -49,8 +49,8 @@ namespace llvm {
     };
 
     enum {
-      // Constant bits for the "flags" field in llvm::MachO::mach_header and
-      // llvm::MachO::mach_header_64
+      // Constant bits for the "flags" field in llvm_ks::MachO::mach_header and
+      // llvm_ks::MachO::mach_header_64
       MH_NOUNDEFS                = 0x00000001u,
       MH_INCRLINK                = 0x00000002u,
       MH_DYLDLINK                = 0x00000004u,
@@ -80,12 +80,12 @@ namespace llvm {
     };
 
     enum : uint32_t {
-      // Flags for the "cmd" field in llvm::MachO::load_command
+      // Flags for the "cmd" field in llvm_ks::MachO::load_command
       LC_REQ_DYLD    = 0x80000000u
     };
 
     enum LoadCommandType : uint32_t {
-      // Constants for the "cmd" field in llvm::MachO::load_command
+      // Constants for the "cmd" field in llvm_ks::MachO::load_command
       LC_SEGMENT              = 0x00000001u,
       LC_SYMTAB               = 0x00000002u,
       LC_SYMSEG               = 0x00000003u,
@@ -138,14 +138,14 @@ namespace llvm {
     };
 
     enum : uint32_t {
-      // Constant bits for the "flags" field in llvm::MachO::segment_command
+      // Constant bits for the "flags" field in llvm_ks::MachO::segment_command
       SG_HIGHVM              = 0x1u,
       SG_FVMLIB              = 0x2u,
       SG_NORELOC             = 0x4u,
       SG_PROTECTED_VERSION_1 = 0x8u,
 
-      // Constant masks for the "flags" field in llvm::MachO::section and
-      // llvm::MachO::section_64
+      // Constant masks for the "flags" field in llvm_ks::MachO::section and
+      // llvm_ks::MachO::section_64
       SECTION_TYPE           = 0x000000ffu, // SECTION_TYPE
       SECTION_ATTRIBUTES     = 0xffffff00u, // SECTION_ATTRIBUTES
       SECTION_ATTRIBUTES_USR = 0xff000000u, // SECTION_ATTRIBUTES_USR
@@ -155,8 +155,8 @@ namespace llvm {
     /// These are the section type and attributes fields.  A MachO section can
     /// have only one Type, but can have any of the attributes specified.
     enum SectionType : uint32_t {
-      // Constant masks for the "flags[7:0]" field in llvm::MachO::section and
-      // llvm::MachO::section_64 (mask "flags" with SECTION_TYPE)
+      // Constant masks for the "flags[7:0]" field in llvm_ks::MachO::section and
+      // llvm_ks::MachO::section_64 (mask "flags" with SECTION_TYPE)
 
       /// S_REGULAR - Regular section.
       S_REGULAR                             = 0x00u,
@@ -216,8 +216,8 @@ namespace llvm {
     };
 
     enum : uint32_t {
-      // Constant masks for the "flags[31:24]" field in llvm::MachO::section and
-      // llvm::MachO::section_64 (mask "flags" with SECTION_ATTRIBUTES_USR)
+      // Constant masks for the "flags[31:24]" field in llvm_ks::MachO::section and
+      // llvm_ks::MachO::section_64 (mask "flags" with SECTION_ATTRIBUTES_USR)
 
       /// S_ATTR_PURE_INSTRUCTIONS - Section contains only true machine
       /// instructions.
@@ -238,8 +238,8 @@ namespace llvm {
       /// S_ATTR_DEBUG - A debug section.
       S_ATTR_DEBUG               = 0x02000000u,
 
-      // Constant masks for the "flags[23:8]" field in llvm::MachO::section and
-      // llvm::MachO::section_64 (mask "flags" with SECTION_ATTRIBUTES_SYS)
+      // Constant masks for the "flags[23:8]" field in llvm_ks::MachO::section and
+      // llvm_ks::MachO::section_64 (mask "flags" with SECTION_ATTRIBUTES_SYS)
 
       /// S_ATTR_SOME_INSTRUCTIONS - Section contains some machine instructions.
       S_ATTR_SOME_INSTRUCTIONS   = 0x00000400u,
@@ -336,8 +336,8 @@ namespace llvm {
     };
 
     enum {
-      // Constant masks for the "n_type" field in llvm::MachO::nlist and
-      // llvm::MachO::nlist_64
+      // Constant masks for the "n_type" field in llvm_ks::MachO::nlist and
+      // llvm_ks::MachO::nlist_64
       N_STAB = 0xe0,
       N_PEXT = 0x10,
       N_TYPE = 0x0e,
@@ -345,8 +345,8 @@ namespace llvm {
     };
 
     enum NListType {
-      // Constants for the "n_type & N_TYPE" llvm::MachO::nlist and
-      // llvm::MachO::nlist_64
+      // Constants for the "n_type & N_TYPE" llvm_ks::MachO::nlist and
+      // llvm_ks::MachO::nlist_64
       N_UNDF = 0x0u,
       N_ABS  = 0x2u,
       N_SECT = 0xeu,
@@ -355,15 +355,15 @@ namespace llvm {
     };
 
     enum SectionOrdinal {
-      // Constants for the "n_sect" field in llvm::MachO::nlist and
-      // llvm::MachO::nlist_64
+      // Constants for the "n_sect" field in llvm_ks::MachO::nlist and
+      // llvm_ks::MachO::nlist_64
       NO_SECT  = 0u,
       MAX_SECT = 0xffu
     };
 
     enum {
-      // Constant masks for the "n_desc" field in llvm::MachO::nlist and
-      // llvm::MachO::nlist_64
+      // Constant masks for the "n_desc" field in llvm_ks::MachO::nlist and
+      // llvm_ks::MachO::nlist_64
       // The low 3 bits are the for the REFERENCE_TYPE.
       REFERENCE_TYPE                            = 0x7,
       REFERENCE_FLAG_UNDEFINED_NON_LAZY         = 0,
@@ -389,8 +389,8 @@ namespace llvm {
     };
 
     enum StabType {
-      // Constant values for the "n_type" field in llvm::MachO::nlist and
-      // llvm::MachO::nlist_64 when "(n_type & N_STAB) != 0"
+      // Constant values for the "n_type" field in llvm_ks::MachO::nlist and
+      // llvm_ks::MachO::nlist_64 when "(n_type & N_STAB) != 0"
       N_GSYM    = 0x20u,
       N_FNAME   = 0x22u,
       N_FUN     = 0x24u,
@@ -426,17 +426,17 @@ namespace llvm {
 
     enum : uint32_t {
       // Constant values for the r_symbolnum field in an
-      // llvm::MachO::relocation_info structure when r_extern is 0.
+      // llvm_ks::MachO::relocation_info structure when r_extern is 0.
       R_ABS = 0,
 
       // Constant bits for the r_address field in an
-      // llvm::MachO::relocation_info structure.
+      // llvm_ks::MachO::relocation_info structure.
       R_SCATTERED = 0x80000000
     };
 
     enum RelocationInfoType {
       // Constant values for the r_type field in an
-      // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
+      // llvm_ks::MachO::relocation_info or llvm_ks::MachO::scattered_relocation_info
       // structure.
       GENERIC_RELOC_VANILLA        = 0,
       GENERIC_RELOC_PAIR           = 1,
@@ -446,7 +446,7 @@ namespace llvm {
       GENERIC_RELOC_TLV            = 5,
 
       // Constant values for the r_type field in a PowerPC architecture
-      // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
+      // llvm_ks::MachO::relocation_info or llvm_ks::MachO::scattered_relocation_info
       // structure.
       PPC_RELOC_VANILLA            = GENERIC_RELOC_VANILLA,
       PPC_RELOC_PAIR               = GENERIC_RELOC_PAIR,
@@ -466,7 +466,7 @@ namespace llvm {
       PPC_RELOC_LOCAL_SECTDIFF     = 15,
 
       // Constant values for the r_type field in an ARM architecture
-      // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
+      // llvm_ks::MachO::relocation_info or llvm_ks::MachO::scattered_relocation_info
       // structure.
       ARM_RELOC_VANILLA            = GENERIC_RELOC_VANILLA,
       ARM_RELOC_PAIR               = GENERIC_RELOC_PAIR,
@@ -480,7 +480,7 @@ namespace llvm {
       ARM_RELOC_HALF_SECTDIFF      = 9,
 
       // Constant values for the r_type field in an ARM64 architecture
-      // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
+      // llvm_ks::MachO::relocation_info or llvm_ks::MachO::scattered_relocation_info
       // structure.
 
       // For pointers.
@@ -507,7 +507,7 @@ namespace llvm {
       ARM64_RELOC_ADDEND              = 10,
 
       // Constant values for the r_type field in an x86_64 architecture
-      // llvm::MachO::relocation_info or llvm::MachO::scattered_relocation_info
+      // llvm_ks::MachO::relocation_info or llvm_ks::MachO::scattered_relocation_info
       // structure
       X86_64_RELOC_UNSIGNED        = 0,
       X86_64_RELOC_SIGNED          = 1,
@@ -1670,6 +1670,6 @@ namespace llvm {
       sizeof(x86_exception_state_t) / sizeof(uint32_t);
 
   } // end namespace MachO
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -28,7 +28,7 @@
 #include <android/api-level.h>
 #endif
 
-namespace llvm {
+namespace llvm_ks {
 /// \brief The behavior an operation has on an input of 0.
 enum ZeroBehavior {
   /// \brief The returned value is undefined.

--- a/llvm/include/llvm/Support/Memory.h
+++ b/llvm/include/llvm/Support/Memory.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::Memory class.
+// This file declares the llvm_ks::sys::Memory class.
 //
 //===----------------------------------------------------------------------===//
 
@@ -18,7 +18,7 @@
 #include <string>
 #include <system_error>
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
   /// This class encapsulates the notion of a memory block which has an address

--- a/llvm/include/llvm/Support/MemoryBuffer.h
+++ b/llvm/include/llvm/Support/MemoryBuffer.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/ErrorOr.h"
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 class MemoryBufferRef;
 
 /// This interface provides simple read-only access to a block of memory, and
@@ -168,6 +168,6 @@ public:
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(MemoryBuffer, LLVMMemoryBufferRef)
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/MemoryObject.h
+++ b/llvm/include/llvm/Support/MemoryObject.h
@@ -12,7 +12,7 @@
 
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Interface to data which might be streamed. Streamability has 2 important
 /// implications/restrictions. First, the data might not yet exist in memory

--- a/llvm/include/llvm/Support/MipsABIFlags.h
+++ b/llvm/include/llvm/Support/MipsABIFlags.h
@@ -17,7 +17,7 @@
 #ifndef LLVM_SUPPORT_MIPSABIFLAGS_H
 #define LLVM_SUPPORT_MIPSABIFLAGS_H
 
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
 
 // Values for the xxx_size bytes of an ABI flags structure.

--- a/llvm/include/llvm/Support/Mutex.h
+++ b/llvm/include/llvm/Support/Mutex.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::Mutex class.
+// This file declares the llvm_ks::sys::Mutex class.
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,7 +17,7 @@
 #include "llvm/Support/Compiler.h"
 #include <cassert>
 
-namespace llvm
+namespace llvm_ks
 {
   namespace sys
   {

--- a/llvm/include/llvm/Support/MutexGuard.h
+++ b/llvm/include/llvm/Support/MutexGuard.h
@@ -17,7 +17,7 @@
 
 #include "llvm/Support/Mutex.h"
 
-namespace llvm {
+namespace llvm_ks {
   /// Instances of this class acquire a given Mutex Lock when constructed and
   /// hold that lock until destruction. The intention is to instantiate one of
   /// these on the stack at the top of some scope to be assured that C++

--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::path namespace. It is designed after
+// This file declares the llvm_ks::sys::path namespace. It is designed after
 // TR2/boost filesystem (v3), but modified to remove exception handling and the
 // path class.
 //
@@ -21,7 +21,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <iterator>
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 namespace path {
 
@@ -432,6 +432,6 @@ bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false);
 
 } // end namespace path
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/PointerLikeTypeTraits.h
+++ b/llvm/include/llvm/Support/PointerLikeTypeTraits.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// A traits type that is used to handle pointer types and things that are just
 /// wrappers for pointers as a uniform entity.
@@ -87,6 +87,6 @@ public:
   enum { NumLowBitsAvailable = 0 };
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/RWMutex.h
+++ b/llvm/include/llvm/Support/RWMutex.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::RWMutex class.
+// This file declares the llvm_ks::sys::RWMutex class.
 //
 //===----------------------------------------------------------------------===//
 
@@ -18,7 +18,7 @@
 #include "llvm/Support/Threading.h"
 #include <cassert>
 
-namespace llvm
+namespace llvm_ks
 {
   namespace sys
   {

--- a/llvm/include/llvm/Support/RandomNumberGenerator.h
+++ b/llvm/include/llvm/Support/RandomNumberGenerator.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/DataTypes.h" // Needed for uint64_t on Windows.
 #include <random>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// A random number generator.
 ///

--- a/llvm/include/llvm/Support/Regex.h
+++ b/llvm/include/llvm/Support/Regex.h
@@ -21,7 +21,7 @@
 
 struct llvm_regex;
 
-namespace llvm {
+namespace llvm_ks {
   class StringRef;
   template<typename T> class SmallVectorImpl;
 

--- a/llvm/include/llvm/Support/Registry.h
+++ b/llvm/include/llvm/Support/Registry.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/Compiler.h"
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
   /// A simple registry entry which provides only a name, description, and
   /// no-argument constructor.
   template <typename T>
@@ -124,6 +124,6 @@ namespace llvm {
 
   template <typename T>
   typename Registry<T>::node *Registry<T>::Tail;
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_SUPPORT_REGISTRY_H

--- a/llvm/include/llvm/Support/SMLoc.h
+++ b/llvm/include/llvm/Support/SMLoc.h
@@ -17,7 +17,7 @@
 
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Represents a location in source code.
 class SMLoc {
@@ -58,6 +58,6 @@ public:
   bool isValid() const { return Start.isValid(); }
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -30,7 +30,7 @@
 #include <tuple>
 #include <utility>
 
-namespace llvm {
+namespace llvm_ks {
 namespace ScaledNumbers {
 
 /// \brief Maximum scale; same as APFloat for easy debug printing.
@@ -412,9 +412,9 @@ inline std::pair<uint64_t, int16_t> getDifference64(uint64_t LDigits,
 }
 
 } // end namespace ScaledNumbers
-} // end namespace llvm
+} // end namespace llvm_ks
 
-namespace llvm {
+namespace llvm_ks {
 
 class raw_ostream;
 class ScaledNumberBase {
@@ -894,6 +894,6 @@ template <typename T> struct isPodLike<ScaledNumber<T>> {
   static const bool value = true;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -23,7 +23,7 @@
 #include "llvm/Support/SMLoc.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
   class SourceMgr;
   class SMDiagnostic;
   class SMFixIt;
@@ -168,7 +168,7 @@ public:
                     ArrayRef<SMFixIt> FixIts = None,
                     bool ShowColors = true) const;
 
-  /// Emits a diagnostic to llvm::errs().
+  /// Emits a diagnostic to llvm_ks::errs().
   void PrintMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
                     ArrayRef<SMRange> Ranges = None,
                     ArrayRef<SMFixIt> FixIts = None,

--- a/llvm/include/llvm/Support/StringPool.h
+++ b/llvm/include/llvm/Support/StringPool.h
@@ -32,7 +32,7 @@
 #include "llvm/ADT/StringMap.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
   class PooledStringPtr;
 

--- a/llvm/include/llvm/Support/StringSaver.h
+++ b/llvm/include/llvm/Support/StringSaver.h
@@ -14,7 +14,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Allocator.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// \brief Saves strings in the inheritor's stable storage and returns a stable
 /// raw character pointer.

--- a/llvm/include/llvm/Support/SwapByteOrder.h
+++ b/llvm/include/llvm/Support/SwapByteOrder.h
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <limits>
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
 /// SwapByteOrder_16 - This function returns a byte-swapped representation of
@@ -120,6 +120,6 @@ inline void swapByteOrder(T &Value) {
 }
 
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/TargetParser.h
+++ b/llvm/include/llvm/Support/TargetParser.h
@@ -19,7 +19,7 @@
 // lists, but SmallVector would probably be better
 #include <vector>
 
-namespace llvm {
+namespace llvm_ks {
 class StringRef;
 
 // Target specific information into their own namespaces. These should be
@@ -140,6 +140,6 @@ unsigned parseArchProfile(StringRef Arch);
 unsigned parseArchVersion(StringRef Arch);
 
 } // namespace ARM
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/TargetRegistry.h
+++ b/llvm/include/llvm/Support/TargetRegistry.h
@@ -25,7 +25,7 @@
 #include <memory>
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class AsmPrinter;
 class MCAsmBackend;
 class MCAsmInfo;
@@ -186,7 +186,7 @@ private:
   ObjectTargetStreamerCtorTy ObjectTargetStreamerCtorFn;
 
   /// MCRelocationInfoCtorFn - Construction function for this target's
-  /// MCRelocationInfo, if registered (default = llvm::createMCRelocationInfo)
+  /// MCRelocationInfo, if registered (default = llvm_ks::createMCRelocationInfo)
   MCRelocationInfoCtorTy MCRelocationInfoCtorFn;
 
 public:
@@ -365,7 +365,7 @@ public:
                                 MCCodeEmitter *CE,
                                 MCAsmBackend *TAB) const {
     formatted_raw_ostream &OSRef = *OS;
-    MCStreamer *S = llvm::createAsmStreamer(Ctx, std::move(OS), CE, TAB);
+    MCStreamer *S = llvm_ks::createAsmStreamer(Ctx, std::move(OS), CE, TAB);
     createAsmTargetStreamer(*S, OSRef);
     return S;
   }
@@ -378,7 +378,7 @@ public:
   }
 
   MCStreamer *createNullStreamer(MCContext &Ctx) const {
-    MCStreamer *S = llvm::createNullStreamer(Ctx);
+    MCStreamer *S = llvm_ks::createNullStreamer(Ctx);
     return S;
   }
 
@@ -389,7 +389,7 @@ public:
   MCRelocationInfo *createMCRelocationInfo(StringRef TT, MCContext &Ctx) const {
     MCRelocationInfoCtorTy Fn = MCRelocationInfoCtorFn
                                     ? MCRelocationInfoCtorFn
-                                    : llvm::createMCRelocationInfo;
+                                    : llvm_ks::createMCRelocationInfo;
     return Fn(Triple(TT), Ctx);
   }
 

--- a/llvm/include/llvm/Support/TargetSelect.h
+++ b/llvm/include/llvm/Support/TargetSelect.h
@@ -35,7 +35,7 @@ extern "C" {
 #include "llvm/Config/AsmParsers.def"
 }
 
-namespace llvm {
+namespace llvm_ks {
   /// InitializeAllTargetInfos - The main program should call this function if
   /// it wants access to all available targets that LLVM is configured to
   /// support, to make them available via the TargetRegistry.

--- a/llvm/include/llvm/Support/Win64EH.h
+++ b/llvm/include/llvm/Support/Win64EH.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Endian.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace Win64EH {
 
 /// UnwindOpcodes - Enumeration whose values specify a single operation in
@@ -142,6 +142,6 @@ struct UnwindInfo {
 
 
 } // End of namespace Win64EH
-} // End of namespace llvm
+} // End of namespace llvm_ks
 
 #endif

--- a/llvm/include/llvm/Support/WindowsError.h
+++ b/llvm/include/llvm/Support/WindowsError.h
@@ -12,7 +12,7 @@
 
 #include <system_error>
 
-namespace llvm {
+namespace llvm_ks {
 std::error_code mapWindowsError(unsigned EV);
 }
 

--- a/llvm/include/llvm/Support/circular_raw_ostream.h
+++ b/llvm/include/llvm/Support/circular_raw_ostream.h
@@ -17,7 +17,7 @@
 
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
   /// circular_raw_ostream - A raw_ostream which *can* save its data
   /// to a circular buffer, or can pass it through directly to an
   /// underlying stream if specified with a buffer of zero.

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <system_error>
 
-namespace llvm {
+namespace llvm_ks {
 class format_object_base;
 class FormattedString;
 class FormattedNumber;
@@ -184,7 +184,7 @@ public:
     return write(Str.data(), Str.length());
   }
 
-  raw_ostream &operator<<(const llvm::SmallVectorImpl<char> &Str) {
+  raw_ostream &operator<<(const llvm_ks::SmallVectorImpl<char> &Str) {
     return write(Str.data(), Str.size());
   }
 

--- a/llvm/include/llvm/Support/type_traits.h
+++ b/llvm/include/llvm/Support/type_traits.h
@@ -22,7 +22,7 @@
 #define __has_feature(x) 0
 #endif
 
-namespace llvm {
+namespace llvm_ks {
 
 /// isPodLike - This is a type trait that is used to determine whether a given
 /// type can be copied around with memcpy instead of running ctors etc.

--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -18,7 +18,7 @@
 
 #include "ks_priv.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 
 KEYSTONE_EXPORT
@@ -198,9 +198,9 @@ static ks_err InitKs(int arch, ks_engine *ks, std::string TripleName)
     if (!initialized) {
         initialized = true;
         // Initialize targets and assembly parsers.
-        llvm::InitializeAllTargetInfos();
-        llvm::InitializeAllTargetMCs();
-        llvm::InitializeAllAsmParsers();
+        llvm_ks::InitializeAllTargetInfos();
+        llvm_ks::InitializeAllTargetMCs();
+        llvm_ks::InitializeAllAsmParsers();
     }
 
     ks->TripleName = Triple::normalize(TripleName);

--- a/llvm/lib/MC/ConstantPools.cpp
+++ b/llvm/lib/MC/ConstantPools.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 //
 // ConstantPool implementation
 //

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -34,7 +34,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/StringSaver.h"
 #include <vector>
-using namespace llvm;
+using namespace llvm_ks;
 
 #undef  DEBUG_TYPE
 #define DEBUG_TYPE "reloc-info"
@@ -98,7 +98,7 @@ class ELFObjectWriter : public MCObjectWriter {
 
     DenseMap<const MCSymbolELF *, const MCSymbolELF *> Renames;
 
-    llvm::DenseMap<const MCSectionELF *, std::vector<ELFRelocationEntry>>
+    llvm_ks::DenseMap<const MCSectionELF *, std::vector<ELFRelocationEntry>>
         Relocations;
 
     /// @}
@@ -1266,7 +1266,7 @@ bool ELFObjectWriter::isWeak(const MCSymbol &S) const {
   return Sec.getGroup();
 }
 
-MCObjectWriter *llvm::createELFObjectWriter(MCELFObjectTargetWriter *MOTW,
+MCObjectWriter *llvm_ks::createELFObjectWriter(MCELFObjectTargetWriter *MOTW,
                                             raw_pwrite_stream &OS,
                                             bool IsLittleEndian) {
   return new ELFObjectWriter(MOTW, OS, IsLittleEndian);

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -10,7 +10,7 @@
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/MC/MCFixupKindInfo.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmBackend::MCAsmBackend() : HasDataInCodeSupport(false) {}
 

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Support/Dwarf.h"
 #include <cctype>
 #include <cstring>
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmInfo::MCAsmInfo() {
   PointerSize = 4;

--- a/llvm/lib/MC/MCAsmInfoCOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoCOFF.cpp
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCAsmInfoCOFF.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmInfoCOFF::MCAsmInfoCOFF() {
   // MingW 4.5 and later support .comm with log2 alignment, but .lcomm uses byte

--- a/llvm/lib/MC/MCAsmInfoDarwin.cpp
+++ b/llvm/lib/MC/MCAsmInfoDarwin.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCSectionMachO.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 bool MCAsmInfoDarwin::isSectionAtomizableBySymbols(
     const MCSection &Section) const {

--- a/llvm/lib/MC/MCAsmInfoELF.cpp
+++ b/llvm/lib/MC/MCAsmInfoELF.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/Support/ELF.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCSection *MCAsmInfoELF::getNonexecutableStackSection(MCContext &Ctx) const {
   if (!UsesNonexecutableStackSection)

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -32,7 +32,7 @@
 
 #include "keystone/keystone.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "assembler"
 
@@ -692,7 +692,7 @@ std::pair<uint64_t, bool> MCAssembler::handleFixup(const MCAsmLayout &Layout,
 void MCAssembler::layout(MCAsmLayout &Layout, unsigned int &KsError)
 {
   DEBUG_WITH_TYPE("mc-dump", {
-      llvm::errs() << "assembler backend - pre-layout\n--\n";
+      llvm_ks::errs() << "assembler backend - pre-layout\n--\n";
       dump(); });
 
   // Create dummy fragments and assign section ordinals.
@@ -721,14 +721,14 @@ void MCAssembler::layout(MCAsmLayout &Layout, unsigned int &KsError)
     continue;
 
   DEBUG_WITH_TYPE("mc-dump", {
-      llvm::errs() << "assembler backend - post-relaxation\n--\n";
+      llvm_ks::errs() << "assembler backend - post-relaxation\n--\n";
       dump(); });
 
   // Finalize the layout, including fragment lowering.
   finishLayout(Layout);
 
   DEBUG_WITH_TYPE("mc-dump", {
-      llvm::errs() << "assembler backend - final-layout\n--\n";
+      llvm_ks::errs() << "assembler backend - final-layout\n--\n";
       dump(); });
 
   // Allow the object writer a chance to perform post-layout binding (for

--- a/llvm/lib/MC/MCCodeEmitter.cpp
+++ b/llvm/lib/MC/MCCodeEmitter.cpp
@@ -9,7 +9,7 @@
 
 #include "llvm/MC/MCCodeEmitter.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCCodeEmitter::MCCodeEmitter() {
 }

--- a/llvm/lib/MC/MCContext.cpp
+++ b/llvm/lib/MC/MCContext.cpp
@@ -32,7 +32,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include <map>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCContext::MCContext(const MCAsmInfo *mai, const MCRegisterInfo *mri,
                      const MCObjectFileInfo *mofi, const SourceMgr *mgr,
@@ -44,7 +44,7 @@ MCContext::MCContext(const MCAsmInfo *mai, const MCRegisterInfo *mri,
       AllowTemporaryLabels(true), DwarfCompileUnitID(0),
       AutoReset(DoAutoReset), HadError(false), BaseAddress(BaseAddr) {
 
-  std::error_code EC = llvm::sys::fs::current_path(CompilationDir);
+  std::error_code EC = llvm_ks::sys::fs::current_path(CompilationDir);
   if (EC)
     CompilationDir.clear();
 

--- a/llvm/lib/MC/MCELFObjectTargetWriter.cpp
+++ b/llvm/lib/MC/MCELFObjectTargetWriter.cpp
@@ -12,7 +12,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCValue.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCELFObjectTargetWriter::MCELFObjectTargetWriter(bool Is64Bit_,
                                                  uint8_t OSABI_,

--- a/llvm/lib/MC/MCELFStreamer.cpp
+++ b/llvm/lib/MC/MCELFStreamer.cpp
@@ -38,7 +38,7 @@
 
 //#include <iostream>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 bool MCELFStreamer::isBundleLocked() const {
   return getCurrentSectionOnly()->isBundleLocked();
@@ -640,7 +640,7 @@ unsigned int MCELFStreamer::FinishImpl()
   return this->MCObjectStreamer::FinishImpl();
 }
 
-MCStreamer *llvm::createELFStreamer(MCContext &Context, MCAsmBackend &MAB,
+MCStreamer *llvm_ks::createELFStreamer(MCContext &Context, MCAsmBackend &MAB,
                                     raw_pwrite_stream &OS, MCCodeEmitter *CE,
                                     bool RelaxAll) {
   MCELFStreamer *S = new MCELFStreamer(Context, MAB, OS, CE);

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -19,7 +19,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mcexpr"
 

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -26,7 +26,7 @@
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 #include <tuple>
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmLayout::MCAsmLayout(MCAssembler &Asm)
   : Assembler(Asm), LastValidFragment()
@@ -218,7 +218,7 @@ uint64_t MCAsmLayout::getSectionFileSize(const MCSection *Sec) const {
   return getSectionAddressSize(Sec);
 }
 
-uint64_t llvm::computeBundlePadding(const MCAssembler &Assembler,
+uint64_t llvm_ks::computeBundlePadding(const MCAssembler &Assembler,
                                     const MCFragment *F,
                                     uint64_t FOffset, uint64_t FSize) {
   uint64_t BundleSize = Assembler.getBundleAlignSize();
@@ -328,7 +328,7 @@ void MCFragment::destroy() {
 
 // Debugging methods
 
-namespace llvm {
+namespace llvm_ks {
 
 raw_ostream &operator<<(raw_ostream &OS, const MCFixup &AF) {
   OS << "<MCFixup" << " Offset:" << AF.getOffset()
@@ -341,7 +341,7 @@ raw_ostream &operator<<(raw_ostream &OS, const MCFixup &AF) {
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCFragment::dump() {
-  raw_ostream &OS = llvm::errs();
+  raw_ostream &OS = llvm_ks::errs();
 
   OS << "<";
   switch (getKind()) {
@@ -462,7 +462,7 @@ LLVM_DUMP_METHOD void MCFragment::dump() {
 }
 
 LLVM_DUMP_METHOD void MCAssembler::dump() {
-  raw_ostream &OS = llvm::errs();
+  raw_ostream &OS = llvm_ks::errs();
 
   OS << "<MCAssembler\n";
   OS << "  Sections:[\n    ";

--- a/llvm/lib/MC/MCInst.cpp
+++ b/llvm/lib/MC/MCInst.cpp
@@ -12,7 +12,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 void MCOperand::print(raw_ostream &OS) const {
   OS << "<MCOperand ";

--- a/llvm/lib/MC/MCInstrDesc.cpp
+++ b/llvm/lib/MC/MCInstrDesc.cpp
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 bool MCInstrDesc::getDeprecatedInfo(MCInst &MI, const MCSubtargetInfo &STI,
                                     std::string &Info) const {

--- a/llvm/lib/MC/MCLabel.cpp
+++ b/llvm/lib/MC/MCLabel.cpp
@@ -10,7 +10,7 @@
 #include "llvm/MC/MCLabel.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 void MCLabel::print(raw_ostream &OS) const {
   OS << '"' << getInstance() << '"';

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCSectionMachO.h"
 #include "llvm/Support/COFF.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static bool useCompactUnwind(const Triple &T) {
   // Only on darwin.

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -24,7 +24,7 @@
 
 //#include <iostream>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCObjectStreamer::MCObjectStreamer(MCContext &Context, MCAsmBackend &TAB,
                                    raw_pwrite_stream &OS,

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -12,7 +12,7 @@
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSymbol.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCObjectWriter::~MCObjectWriter() {
 }

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -19,7 +19,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
-using namespace llvm;
+using namespace llvm_ks;
 
 AsmLexer::AsmLexer(const MCAsmInfo &MAI) : MAI(MAI) {
   CurPtr = nullptr;

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -47,7 +47,7 @@
 #include <keystone/keystone.h>
 //#include <iostream>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmParserSemaCallback::~MCAsmParserSemaCallback() {}
 
@@ -529,7 +529,7 @@ private:
 };
 }
 
-namespace llvm {
+namespace llvm_ks {
 
 extern MCAsmParserExtension *createDarwinAsmParser();
 extern MCAsmParserExtension *createELFAsmParser();
@@ -6023,7 +6023,7 @@ bool AsmParser::parseMSInlineAsm(
   return false;
 }
 
-namespace llvm {
+namespace llvm_ks {
 namespace MCParserUtils {
 
 /// Returns whether the given symbol is used anywhere in the given expression,
@@ -6122,10 +6122,10 @@ bool parseAssignmentExpression(StringRef Name, bool allow_redef,
 }
 
 } // namespace MCParserUtils
-} // namespace llvm
+} // namespace llvm_ks
 
 /// \brief Create an MCAsmParser instance.
-MCAsmParser *llvm::createMCAsmParser(SourceMgr &SM, MCContext &C,
+MCAsmParser *llvm_ks::createMCAsmParser(SourceMgr &SM, MCContext &C,
                                      MCStreamer &Out, const MCAsmInfo &MAI) {
   return new AsmParser(SM, C, Out, MAI);
 }

--- a/llvm/lib/MC/MCParser/COFFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/COFFAsmParser.cpp
@@ -20,7 +20,7 @@
 #include "llvm/MC/MCSectionCOFF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/COFF.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -793,7 +793,7 @@ bool COFFAsmParser::ParseSEHRegisterNumber(unsigned &RegNo) {
   return false;
 }
 
-namespace llvm {
+namespace llvm_ks {
 
 MCAsmParserExtension *createCOFFAsmParser() {
   return new COFFAsmParser;

--- a/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/DarwinAsmParser.cpp
@@ -23,7 +23,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -670,7 +670,7 @@ bool DarwinAsmParser::parseDirectiveSecureLogUnique(StringRef, SMLoc IDLoc) {
   raw_fd_ostream *OS = getContext().getSecureLog();
   if (!OS) {
     std::error_code EC;
-    auto NewOS = llvm::make_unique<raw_fd_ostream>(
+    auto NewOS = llvm_ks::make_unique<raw_fd_ostream>(
         SecureLogFile, EC, sys::fs::F_Append | sys::fs::F_Text);
     if (EC)
        return Error(IDLoc, Twine("can't open secure log file: ") +
@@ -959,7 +959,7 @@ bool DarwinAsmParser::parseVersionMin(StringRef Directive, SMLoc Loc) {
   return false;
 }
 
-namespace llvm {
+namespace llvm_ks {
 
 MCAsmParserExtension *createDarwinAsmParser() {
   return new DarwinAsmParser;

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbolELF.h"
 #include "llvm/Support/ELF.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -737,7 +737,7 @@ bool ELFAsmParser::ParseDirectiveSubsection(StringRef, SMLoc) {
   return false;
 }
 
-namespace llvm {
+namespace llvm_ks {
 
 MCAsmParserExtension *createELFAsmParser() {
   return new ELFAsmParser;

--- a/llvm/lib/MC/MCParser/MCAsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmLexer.cpp
@@ -10,7 +10,7 @@
 #include "llvm/MC/MCParser/MCAsmLexer.h"
 #include "llvm/Support/SourceMgr.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmLexer::MCAsmLexer() : TokStart(nullptr), SkipSpace(true) {
   CurTok.emplace_back(AsmToken::Error, StringRef());

--- a/llvm/lib/MC/MCParser/MCAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmParser.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmParser::MCAsmParser() : TargetParser(nullptr), KsError(0) {
 }

--- a/llvm/lib/MC/MCParser/MCAsmParserExtension.cpp
+++ b/llvm/lib/MC/MCParser/MCAsmParserExtension.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCParser/MCAsmParserExtension.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCAsmParserExtension::MCAsmParserExtension() :
   BracketExpressionsSupported(false) {

--- a/llvm/lib/MC/MCParser/MCTargetAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/MCTargetAsmParser.cpp
@@ -9,7 +9,7 @@
 
 #include "llvm/MC/MCParser/MCTargetAsmParser.h"
 #include "llvm/MC/MCContext.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCTargetAsmParser::MCTargetAsmParser(MCTargetOptions const &MCOptions,
                                      const MCSubtargetInfo &STI)

--- a/llvm/lib/MC/MCRegisterInfo.cpp
+++ b/llvm/lib/MC/MCRegisterInfo.cpp
@@ -13,7 +13,7 @@
 
 #include "llvm/MC/MCRegisterInfo.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 unsigned MCRegisterInfo::getMatchingSuperReg(unsigned Reg, unsigned SubIdx,
                                              const MCRegisterClass *RC) const {

--- a/llvm/lib/MC/MCSection.cpp
+++ b/llvm/lib/MC/MCSection.cpp
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 //===----------------------------------------------------------------------===//
 // MCSection
@@ -87,7 +87,7 @@ MCSection::getSubsectionInsertionPoint(unsigned Subsection) {
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void MCSection::dump() {
-  raw_ostream &OS = llvm::errs();
+  raw_ostream &OS = llvm_ks::errs();
 
   OS << "<MCSection";
   OS << " Fragments:[\n      ";

--- a/llvm/lib/MC/MCSectionCOFF.cpp
+++ b/llvm/lib/MC/MCSectionCOFF.cpp
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/COFF.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 MCSectionCOFF::~MCSectionCOFF() {} // anchor.
 

--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Support/ELF.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MCSectionELF::~MCSectionELF() {} // anchor.
 

--- a/llvm/lib/MC/MCSectionMachO.cpp
+++ b/llvm/lib/MC/MCSectionMachO.cpp
@@ -11,7 +11,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cctype>
-using namespace llvm;
+using namespace llvm_ks;
 
 /// SectionTypeDescriptors - These are strings that describe the various section
 /// types.  This *must* be kept in order with and stay synchronized with the

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -27,7 +27,7 @@
 
 //#include <iostream>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // Pin the vtables to this file.
 MCTargetStreamer::~MCTargetStreamer() {}

--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -14,7 +14,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static FeatureBitset getFeatures(StringRef CPU, StringRef FS,
                                  ArrayRef<SubtargetFeatureKV> ProcDesc,

--- a/llvm/lib/MC/MCSymbol.cpp
+++ b/llvm/lib/MC/MCSymbol.cpp
@@ -14,7 +14,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 // Only the address of this fragment is ever actually used.
 static MCDummyFragment SentinelFragment(nullptr);

--- a/llvm/lib/MC/MCSymbolELF.cpp
+++ b/llvm/lib/MC/MCSymbolELF.cpp
@@ -12,7 +12,7 @@
 #include "llvm/MC/MCFixupKindInfo.h"
 #include "llvm/Support/ELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace {
 enum {

--- a/llvm/lib/MC/MCTargetOptions.cpp
+++ b/llvm/lib/MC/MCTargetOptions.cpp
@@ -10,7 +10,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCTargetOptions.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 MCTargetOptions::MCTargetOptions()
     : MCRelaxAll(false),
@@ -21,4 +21,4 @@ StringRef MCTargetOptions::getABIName() const {
   return ABIName;
 }
 
-} // end namespace llvm
+} // end namespace llvm_ks

--- a/llvm/lib/MC/MCValue.cpp
+++ b/llvm/lib/MC/MCValue.cpp
@@ -13,7 +13,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 void MCValue::print(raw_ostream &OS) const {
   if (isAbsolute()) {

--- a/llvm/lib/MC/StringTableBuilder.cpp
+++ b/llvm/lib/MC/StringTableBuilder.cpp
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 StringTableBuilder::StringTableBuilder(Kind K) : K(K) {
   // Account for leading bytes in table so that offsets returned from add are

--- a/llvm/lib/MC/SubtargetFeature.cpp
+++ b/llvm/lib/MC/SubtargetFeature.cpp
@@ -20,7 +20,7 @@
 #include <cassert>
 #include <cctype>
 #include <cstdlib>
-using namespace llvm;
+using namespace llvm_ks;
 
 //===----------------------------------------------------------------------===//
 //                          Static Helper Functions

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <limits.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 /// A macro used to combine two fcCategory enums into one key which can be used
 /// in a switch statement to classify how the interaction of two APFloat's
@@ -37,7 +37,7 @@ using namespace llvm;
    hexadecimal strings.  */
 static_assert(integerPartWidth % 4 == 0, "Part width must be divisible by 4!");
 
-namespace llvm {
+namespace llvm_ks {
 
   /* Represents floating point arithmetic semantics.  */
   struct fltSemantics {
@@ -2900,7 +2900,7 @@ APFloat::convertNormalToHexString(char *dst, unsigned int hexDigits,
   return writeSignedDecimal (dst, exponent);
 }
 
-hash_code llvm::hash_value(const APFloat &Arg) {
+hash_code llvm_ks::hash_value(const APFloat &Arg) {
   if (!Arg.isFiniteNonZero())
     return hash_combine((uint8_t)Arg.category,
                         // NaN has no sign, fix it at zero.
@@ -2927,7 +2927,7 @@ hash_code llvm::hash_value(const APFloat &Arg) {
 APInt
 APFloat::convertF80LongDoubleAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&x87DoubleExtended);
+  assert(semantics == (const llvm_ks::fltSemantics*)&x87DoubleExtended);
   assert(partCount()==2);
 
   uint64_t myexponent, mysignificand;
@@ -2959,7 +2959,7 @@ APFloat::convertF80LongDoubleAPFloatToAPInt() const
 APInt
 APFloat::convertPPCDoubleDoubleAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&PPCDoubleDouble);
+  assert(semantics == (const llvm_ks::fltSemantics*)&PPCDoubleDouble);
   assert(partCount()==2);
 
   uint64_t words[2];
@@ -3010,7 +3010,7 @@ APFloat::convertPPCDoubleDoubleAPFloatToAPInt() const
 APInt
 APFloat::convertQuadrupleAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEquad);
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEquad);
   assert(partCount()==2);
 
   uint64_t myexponent, mysignificand, mysignificand2;
@@ -3046,7 +3046,7 @@ APFloat::convertQuadrupleAPFloatToAPInt() const
 APInt
 APFloat::convertDoubleAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEdouble);
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEdouble);
   assert(partCount()==1);
 
   uint64_t myexponent, mysignificand;
@@ -3076,7 +3076,7 @@ APFloat::convertDoubleAPFloatToAPInt() const
 APInt
 APFloat::convertFloatAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEsingle);
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEsingle);
   assert(partCount()==1);
 
   uint32_t myexponent, mysignificand;
@@ -3105,7 +3105,7 @@ APFloat::convertFloatAPFloatToAPInt() const
 APInt
 APFloat::convertHalfAPFloatToAPInt() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEhalf);
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEhalf);
   assert(partCount()==1);
 
   uint32_t myexponent, mysignificand;
@@ -3138,22 +3138,22 @@ APFloat::convertHalfAPFloatToAPInt() const
 APInt
 APFloat::bitcastToAPInt() const
 {
-  if (semantics == (const llvm::fltSemantics*)&IEEEhalf)
+  if (semantics == (const llvm_ks::fltSemantics*)&IEEEhalf)
     return convertHalfAPFloatToAPInt();
 
-  if (semantics == (const llvm::fltSemantics*)&IEEEsingle)
+  if (semantics == (const llvm_ks::fltSemantics*)&IEEEsingle)
     return convertFloatAPFloatToAPInt();
 
-  if (semantics == (const llvm::fltSemantics*)&IEEEdouble)
+  if (semantics == (const llvm_ks::fltSemantics*)&IEEEdouble)
     return convertDoubleAPFloatToAPInt();
 
-  if (semantics == (const llvm::fltSemantics*)&IEEEquad)
+  if (semantics == (const llvm_ks::fltSemantics*)&IEEEquad)
     return convertQuadrupleAPFloatToAPInt();
 
-  if (semantics == (const llvm::fltSemantics*)&PPCDoubleDouble)
+  if (semantics == (const llvm_ks::fltSemantics*)&PPCDoubleDouble)
     return convertPPCDoubleDoubleAPFloatToAPInt();
 
-  assert(semantics == (const llvm::fltSemantics*)&x87DoubleExtended &&
+  assert(semantics == (const llvm_ks::fltSemantics*)&x87DoubleExtended &&
          "unknown format!");
   return convertF80LongDoubleAPFloatToAPInt();
 }
@@ -3161,7 +3161,7 @@ APFloat::bitcastToAPInt() const
 float
 APFloat::convertToFloat() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEsingle &&
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEsingle &&
          "Float semantics are not IEEEsingle");
   APInt api = bitcastToAPInt();
   return api.bitsToFloat();
@@ -3170,7 +3170,7 @@ APFloat::convertToFloat() const
 double
 APFloat::convertToDouble() const
 {
-  assert(semantics == (const llvm::fltSemantics*)&IEEEdouble &&
+  assert(semantics == (const llvm_ks::fltSemantics*)&IEEEdouble &&
          "Float semantics are not IEEEdouble");
   APInt api = bitcastToAPInt();
   return api.bitsToDouble();
@@ -3980,7 +3980,7 @@ APFloat::makeZero(bool Negative) {
   APInt::tcSet(significandParts(), 0, partCount());  
 }
 
-APFloat llvm::scalbn(APFloat X, int Exp) {
+APFloat llvm_ks::scalbn(APFloat X, int Exp) {
   if (X.isInfinity() || X.isZero() || X.isNaN())
     return X;
 

--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -25,7 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "apint"
 
@@ -667,7 +667,7 @@ unsigned APInt::getBitsNeeded(StringRef str, uint8_t radix) {
   }
 }
 
-hash_code llvm::hash_value(const APInt &Arg) {
+hash_code llvm_ks::hash_value(const APInt &Arg) {
   if (Arg.isSingleWord())
     return hash_combine(Arg.VAL);
 
@@ -707,14 +707,14 @@ unsigned APInt::countLeadingZerosSlowCase() const {
   unsigned i = getNumWords();
   integerPart MSW = pVal[i-1] & MSWMask;
   if (MSW)
-    return llvm::countLeadingZeros(MSW) - (APINT_BITS_PER_WORD - BitsInMSW);
+    return llvm_ks::countLeadingZeros(MSW) - (APINT_BITS_PER_WORD - BitsInMSW);
 
   unsigned Count = BitsInMSW;
   for (--i; i > 0u; --i) {
     if (pVal[i-1] == 0)
       Count += APINT_BITS_PER_WORD;
     else {
-      Count += llvm::countLeadingZeros(pVal[i-1]);
+      Count += llvm_ks::countLeadingZeros(pVal[i-1]);
       break;
     }
   }
@@ -723,7 +723,7 @@ unsigned APInt::countLeadingZerosSlowCase() const {
 
 unsigned APInt::countLeadingOnes() const {
   if (isSingleWord())
-    return llvm::countLeadingOnes(VAL << (APINT_BITS_PER_WORD - BitWidth));
+    return llvm_ks::countLeadingOnes(VAL << (APINT_BITS_PER_WORD - BitWidth));
 
   unsigned highWordBits = BitWidth % APINT_BITS_PER_WORD;
   unsigned shift;
@@ -734,13 +734,13 @@ unsigned APInt::countLeadingOnes() const {
     shift = APINT_BITS_PER_WORD - highWordBits;
   }
   int i = getNumWords() - 1;
-  unsigned Count = llvm::countLeadingOnes(pVal[i] << shift);
+  unsigned Count = llvm_ks::countLeadingOnes(pVal[i] << shift);
   if (Count == highWordBits) {
     for (i--; i >= 0; --i) {
       if (pVal[i] == -1ULL)
         Count += APINT_BITS_PER_WORD;
       else {
-        Count += llvm::countLeadingOnes(pVal[i]);
+        Count += llvm_ks::countLeadingOnes(pVal[i]);
         break;
       }
     }
@@ -750,13 +750,13 @@ unsigned APInt::countLeadingOnes() const {
 
 unsigned APInt::countTrailingZeros() const {
   if (isSingleWord())
-    return std::min(unsigned(llvm::countTrailingZeros(VAL)), BitWidth);
+    return std::min(unsigned(llvm_ks::countTrailingZeros(VAL)), BitWidth);
   unsigned Count = 0;
   unsigned i = 0;
   for (; i < getNumWords() && pVal[i] == 0; ++i)
     Count += APINT_BITS_PER_WORD;
   if (i < getNumWords())
-    Count += llvm::countTrailingZeros(pVal[i]);
+    Count += llvm_ks::countTrailingZeros(pVal[i]);
   return std::min(Count, BitWidth);
 }
 
@@ -766,14 +766,14 @@ unsigned APInt::countTrailingOnesSlowCase() const {
   for (; i < getNumWords() && pVal[i] == -1ULL; ++i)
     Count += APINT_BITS_PER_WORD;
   if (i < getNumWords())
-    Count += llvm::countTrailingOnes(pVal[i]);
+    Count += llvm_ks::countTrailingOnes(pVal[i]);
   return std::min(Count, BitWidth);
 }
 
 unsigned APInt::countPopulationSlowCase() const {
   unsigned Count = 0;
   for (unsigned i = 0; i < getNumWords(); ++i)
-    Count += llvm::countPopulation(pVal[i]);
+    Count += llvm_ks::countPopulation(pVal[i]);
   return Count;
 }
 
@@ -816,7 +816,7 @@ APInt APInt::byteSwap() const {
   return Result;
 }
 
-APInt llvm::APIntOps::GreatestCommonDivisor(const APInt& API1,
+APInt llvm_ks::APIntOps::GreatestCommonDivisor(const APInt& API1,
                                             const APInt& API2) {
   APInt A = API1, B = API2;
   while (!!B) {
@@ -827,7 +827,7 @@ APInt llvm::APIntOps::GreatestCommonDivisor(const APInt& API1,
   return A;
 }
 
-APInt llvm::APIntOps::RoundDoubleToAPInt(double Double, unsigned width) {
+APInt llvm_ks::APIntOps::RoundDoubleToAPInt(double Double, unsigned width) {
   union {
     double D;
     uint64_t I;

--- a/llvm/lib/Support/APSInt.cpp
+++ b/llvm/lib/Support/APSInt.cpp
@@ -15,7 +15,7 @@
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/FoldingSet.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 APSInt::APSInt(StringRef Str) {
   assert(!Str.empty() && "Invalid string length");

--- a/llvm/lib/Support/ARMBuildAttrs.cpp
+++ b/llvm/lib/Support/ARMBuildAttrs.cpp
@@ -10,7 +10,7 @@
 #include "llvm/Support/ARMBuildAttributes.h"
 #include "llvm/ADT/StringRef.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 const struct {
@@ -69,7 +69,7 @@ const struct {
 };
 }
 
-namespace llvm {
+namespace llvm_ks {
 namespace ARMBuildAttrs {
 StringRef AttrTypeAsString(unsigned Attr, bool HasTagPrefix) {
   return AttrTypeAsString(static_cast<AttrType>(Attr), HasTagPrefix);

--- a/llvm/lib/Support/ErrorHandling.cpp
+++ b/llvm/lib/Support/ErrorHandling.cpp
@@ -30,21 +30,21 @@
 # include <fcntl.h>
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 
-void llvm::report_fatal_error(const char *Reason, bool GenCrashDiag) {
+void llvm_ks::report_fatal_error(const char *Reason, bool GenCrashDiag) {
   report_fatal_error(Twine(Reason), GenCrashDiag);
 }
 
-void llvm::report_fatal_error(const std::string &Reason, bool GenCrashDiag) {
+void llvm_ks::report_fatal_error(const std::string &Reason, bool GenCrashDiag) {
   report_fatal_error(Twine(Reason), GenCrashDiag);
 }
 
-void llvm::report_fatal_error(StringRef Reason, bool GenCrashDiag) {
+void llvm_ks::report_fatal_error(StringRef Reason, bool GenCrashDiag) {
   report_fatal_error(Twine(Reason), GenCrashDiag);
 }
 
-void llvm::report_fatal_error(const Twine &Reason, bool GenCrashDiag) {
+void llvm_ks::report_fatal_error(const Twine &Reason, bool GenCrashDiag) {
   // Blast the result out to stderr.  We don't try hard to make sure this
   // succeeds (e.g. handling EINTR) and we can't use errs() here because
   // raw ostreams can call report_fatal_error.
@@ -63,7 +63,7 @@ void llvm::report_fatal_error(const Twine &Reason, bool GenCrashDiag) {
   exit(1);
 }
 
-void llvm::llvm_unreachable_internal(const char *msg, const char *file,
+void llvm_ks::llvm_unreachable_internal(const char *msg, const char *file,
                                      unsigned line) {
   // This code intentionally doesn't call the ErrorHandler callback, because
   // llvm_unreachable is intended to be used to indicate "impossible"
@@ -85,7 +85,7 @@ void llvm::llvm_unreachable_internal(const char *msg, const char *file,
   case x:                                                                      \
     return make_error_code(errc::y)
 
-std::error_code llvm::mapWindowsError(unsigned EV) {
+std::error_code llvm_ks::mapWindowsError(unsigned EV) {
   switch (EV) {
     MAP_ERR_TO_COND(ERROR_ACCESS_DENIED, permission_denied);
     MAP_ERR_TO_COND(ERROR_ALREADY_EXISTS, file_exists);

--- a/llvm/lib/Support/Hashing.cpp
+++ b/llvm/lib/Support/Hashing.cpp
@@ -15,15 +15,15 @@
 
 #include "llvm/ADT/Hashing.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // Provide a definition and static initializer for the fixed seed. This
 // initializer should always be zero to ensure its value can never appear to be
 // non-zero, even during dynamic initialization.
-size_t llvm::hashing::detail::fixed_seed_override = 0;
+size_t llvm_ks::hashing::detail::fixed_seed_override = 0;
 
 // Implement the function for forced setting of the fixed seed.
 // FIXME: Use atomic operations here so that there is no data race.
-void llvm::set_fixed_execution_hash_seed(size_t fixed_value) {
+void llvm_ks::set_fixed_execution_hash_seed(size_t fixed_value) {
   hashing::detail::fixed_seed_override = fixed_value;
 }

--- a/llvm/lib/Support/IntEqClasses.cpp
+++ b/llvm/lib/Support/IntEqClasses.cpp
@@ -20,7 +20,7 @@
 
 #include "llvm/ADT/IntEqClasses.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 void IntEqClasses::grow(unsigned N) {
   assert(NumClasses == 0 && "grow() called after compress().");

--- a/llvm/lib/Support/LEB128.cpp
+++ b/llvm/lib/Support/LEB128.cpp
@@ -14,7 +14,7 @@
 
 #include "llvm/Support/LEB128.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// Utility function to get the size of the ULEB128-encoded value.
 unsigned getULEB128Size(uint64_t Value) {
@@ -41,4 +41,4 @@ unsigned getSLEB128Size(int64_t Value) {
   return Size;
 }
 
-}  // namespace llvm
+}  // namespace llvm_ks

--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -30,7 +30,7 @@
 #else
 #include <io.h>
 #endif
-using namespace llvm;
+using namespace llvm_ks;
 
 //===----------------------------------------------------------------------===//
 // MemoryBuffer implementation itself.

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -27,12 +27,12 @@
 #include <io.h>
 #endif
 
-using namespace llvm;
-using namespace llvm::support::endian;
+using namespace llvm_ks;
+using namespace llvm_ks::support::endian;
 
 namespace {
-  using llvm::StringRef;
-  using llvm::sys::path::is_separator;
+  using llvm_ks::StringRef;
+  using llvm_ks::sys::path::is_separator;
 
 #ifdef LLVM_ON_WIN32
   const char *separators = "\\/";
@@ -225,7 +225,7 @@ retry_random_path:
   llvm_unreachable("Invalid Type");
 }
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys  {
 namespace path {
 
@@ -676,7 +676,7 @@ static SmallString<256> remove_dots(StringRef path, bool remove_dot_dot) {
 
   // Skip the root path, then look for traversal in the components.
   StringRef rel = path::relative_path(path);
-  for (StringRef C : llvm::make_range(path::begin(rel), path::end(rel))) {
+  for (StringRef C : llvm_ks::make_range(path::begin(rel), path::end(rel))) {
     if (C == ".")
       continue;
     if (remove_dot_dot) {
@@ -733,7 +733,7 @@ std::error_code createUniqueFile(const Twine &Model,
 
 static std::error_code
 createTemporaryFile(const Twine &Model, int &ResultFD,
-                    llvm::SmallVectorImpl<char> &ResultPath, FSEntity Type) {
+                    llvm_ks::SmallVectorImpl<char> &ResultPath, FSEntity Type) {
   SmallString<128> Storage;
   StringRef P = Model.toNullTerminatedStringRef(Storage);
   assert(P.find_first_of(separators) == StringRef::npos &&
@@ -745,7 +745,7 @@ createTemporaryFile(const Twine &Model, int &ResultFD,
 
 static std::error_code
 createTemporaryFile(const Twine &Prefix, StringRef Suffix, int &ResultFD,
-                    llvm::SmallVectorImpl<char> &ResultPath, FSEntity Type) {
+                    llvm_ks::SmallVectorImpl<char> &ResultPath, FSEntity Type) {
   const char *Middle = Suffix.empty() ? "-%%%%%%" : "-%%%%%%.";
   return createTemporaryFile(Prefix + Middle + Suffix, ResultFD, ResultPath,
                              Type);
@@ -1132,7 +1132,7 @@ std::error_code directory_entry::status(file_status &result) const {
 
 } // end namespace fs
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks
 
 // Include the truly platform-specific parts.
 #if defined(LLVM_ON_UNIX)
@@ -1142,7 +1142,7 @@ std::error_code directory_entry::status(file_status &result) const {
 #include "Windows/Path.inc"
 #endif
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 namespace path {
 
@@ -1157,4 +1157,4 @@ bool user_cache_directory(SmallVectorImpl<char> &Result, const Twine &Path1,
 
 } // end namespace path
 } // end namsspace sys
-} // end namespace llvm
+} // end namespace llvm_ks

--- a/llvm/lib/Support/Regex.cpp
+++ b/llvm/lib/Support/Regex.cpp
@@ -17,7 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include <string>
-using namespace llvm;
+using namespace llvm_ks;
 
 Regex::Regex(StringRef regex, unsigned Flags) {
   unsigned flags = 0;

--- a/llvm/lib/Support/ScaledNumber.cpp
+++ b/llvm/lib/Support/ScaledNumber.cpp
@@ -16,8 +16,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
-using namespace llvm::ScaledNumbers;
+using namespace llvm_ks;
+using namespace llvm_ks::ScaledNumbers;
 
 std::pair<uint64_t, int16_t> ScaledNumbers::multiply64(uint64_t LHS,
                                                        uint64_t RHS) {

--- a/llvm/lib/Support/SmallPtrSet.cpp
+++ b/llvm/lib/Support/SmallPtrSet.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 #include <cstdlib>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 void SmallPtrSetImplBase::shrink_and_clear() {
   assert(!isSmall() && "Can't shrink a small set!");

--- a/llvm/lib/Support/SmallVector.cpp
+++ b/llvm/lib/Support/SmallVector.cpp
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/SmallVector.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 /// grow_pod - This is an implementation of the grow() method which only works
 /// on POD-like datatypes and is out of line to reduce code duplication.

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -18,7 +18,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 static const size_t TabStop = 8;
 
@@ -221,7 +221,7 @@ void SourceMgr::PrintMessage(raw_ostream &OS, SMLoc Loc,
 void SourceMgr::PrintMessage(SMLoc Loc, SourceMgr::DiagKind Kind,
                              const Twine &Msg, ArrayRef<SMRange> Ranges,
                              ArrayRef<SMFixIt> FixIts, bool ShowColors) const {
-  PrintMessage(llvm::errs(), Loc, Kind, Msg, Ranges, FixIts, ShowColors);
+  PrintMessage(llvm_ks::errs(), Loc, Kind, Msg, Ranges, FixIts, ShowColors);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Support/StringExtras.cpp
+++ b/llvm/lib/Support/StringExtras.cpp
@@ -13,12 +13,12 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 /// StrInStrNoCase - Portable version of strcasestr.  Locates the first
 /// occurrence of string 's1' in string 's2', ignoring case.  Returns
 /// the offset of s2 in s1 or npos if s2 cannot be found.
-StringRef::size_type llvm::StrInStrNoCase(StringRef s1, StringRef s2) {
+StringRef::size_type llvm_ks::StrInStrNoCase(StringRef s1, StringRef s2) {
   size_t N = s2.size(), M = s1.size();
   if (N > M)
     return StringRef::npos;
@@ -34,7 +34,7 @@ StringRef::size_type llvm::StrInStrNoCase(StringRef s1, StringRef s2) {
 /// there are no tokens in the source string, an empty string is returned.
 /// The function returns a pair containing the extracted token and the
 /// remaining tail string.
-std::pair<StringRef, StringRef> llvm::getToken(StringRef Source,
+std::pair<StringRef, StringRef> llvm_ks::getToken(StringRef Source,
                                                StringRef Delimiters) {
   // Figure out where the token starts.
   StringRef::size_type Start = Source.find_first_not_of(Delimiters);
@@ -47,7 +47,7 @@ std::pair<StringRef, StringRef> llvm::getToken(StringRef Source,
 
 /// SplitString - Split up the specified string according to the specified
 /// delimiters, appending the result fragments to the output list.
-void llvm::SplitString(StringRef Source,
+void llvm_ks::SplitString(StringRef Source,
                        SmallVectorImpl<StringRef> &OutFragments,
                        StringRef Delimiters) {
   std::pair<StringRef, StringRef> S = getToken(Source, Delimiters);

--- a/llvm/lib/Support/StringMap.cpp
+++ b/llvm/lib/Support/StringMap.cpp
@@ -15,7 +15,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 #include <cassert>
-using namespace llvm;
+using namespace llvm_ks;
 
 StringMapImpl::StringMapImpl(unsigned InitSize, unsigned itemSize) {
   ItemSize = itemSize;

--- a/llvm/lib/Support/StringPool.cpp
+++ b/llvm/lib/Support/StringPool.cpp
@@ -14,7 +14,7 @@
 #include "llvm/Support/StringPool.h"
 #include "llvm/ADT/StringRef.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 StringPool::StringPool() {}
 

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -13,7 +13,7 @@
 #include "llvm/ADT/edit_distance.h"
 #include <bitset>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // MSVC emits references to this into the translation units which reference it.
 #ifndef _MSC_VER
@@ -101,10 +101,10 @@ int StringRef::compare_numeric(StringRef RHS) const {
 }
 
 // Compute the edit distance between the two given strings.
-unsigned StringRef::edit_distance(llvm::StringRef Other,
+unsigned StringRef::edit_distance(llvm_ks::StringRef Other,
                                   bool AllowReplacements,
                                   unsigned MaxEditDistance) const {
-  return llvm::ComputeEditDistance(
+  return llvm_ks::ComputeEditDistance(
       makeArrayRef(data(), size()),
       makeArrayRef(Other.data(), Other.size()),
       AllowReplacements, MaxEditDistance);
@@ -375,7 +375,7 @@ static unsigned GetAutoSenseRadix(StringRef &Str) {
 
 /// GetAsUnsignedInteger - Workhorse method that converts a integer character
 /// sequence of radix up to 36 to an unsigned long long value.
-bool llvm::getAsUnsignedInteger(StringRef Str, unsigned Radix,
+bool llvm_ks::getAsUnsignedInteger(StringRef Str, unsigned Radix,
                                 unsigned long long &Result) {
   // Autosense radix if not specified.
   if (Radix == 0)
@@ -416,7 +416,7 @@ bool llvm::getAsUnsignedInteger(StringRef Str, unsigned Radix,
   return false;
 }
 
-bool llvm::getAsSignedInteger(StringRef Str, unsigned Radix,
+bool llvm_ks::getAsSignedInteger(StringRef Str, unsigned Radix,
                               long long &Result) {
   unsigned long long ULLVal;
 
@@ -519,6 +519,6 @@ bool StringRef::getAsInteger(unsigned Radix, APInt &Result) const {
 
 
 // Implementation of StringRef hashing.
-hash_code llvm::hash_value(StringRef S) {
+hash_code llvm_ks::hash_value(StringRef S) {
   return hash_combine_range(S.begin(), S.end());
 }

--- a/llvm/lib/Support/StringSaver.cpp
+++ b/llvm/lib/Support/StringSaver.cpp
@@ -9,7 +9,7 @@
 
 #include "llvm/Support/StringSaver.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 const char *StringSaver::save(StringRef S) {
   char *P = Alloc.Allocate<char>(S.size() + 1);

--- a/llvm/lib/Support/TargetParser.cpp
+++ b/llvm/lib/Support/TargetParser.cpp
@@ -19,7 +19,7 @@
 #include "llvm/ADT/Twine.h"
 #include <cctype>
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace ARM;
 
 namespace {
@@ -132,31 +132,31 @@ static const struct {
 // Information by ID
 // ======================================================= //
 
-StringRef llvm::ARM::getFPUName(unsigned FPUKind) {
+StringRef llvm_ks::ARM::getFPUName(unsigned FPUKind) {
   if (FPUKind >= ARM::FK_LAST)
     return StringRef();
   return FPUNames[FPUKind].getName();
 }
 
-unsigned llvm::ARM::getFPUVersion(unsigned FPUKind) {
+unsigned llvm_ks::ARM::getFPUVersion(unsigned FPUKind) {
   if (FPUKind >= ARM::FK_LAST)
     return 0;
   return FPUNames[FPUKind].FPUVersion;
 }
 
-unsigned llvm::ARM::getFPUNeonSupportLevel(unsigned FPUKind) {
+unsigned llvm_ks::ARM::getFPUNeonSupportLevel(unsigned FPUKind) {
   if (FPUKind >= ARM::FK_LAST)
     return 0;
   return FPUNames[FPUKind].NeonSupport;
 }
 
-unsigned llvm::ARM::getFPURestriction(unsigned FPUKind) {
+unsigned llvm_ks::ARM::getFPURestriction(unsigned FPUKind) {
   if (FPUKind >= ARM::FK_LAST)
     return 0;
   return FPUNames[FPUKind].Restriction;
 }
 
-unsigned llvm::ARM::getDefaultFPU(StringRef CPU, unsigned ArchKind) {
+unsigned llvm_ks::ARM::getDefaultFPU(StringRef CPU, unsigned ArchKind) {
   if (CPU == "generic")
     return ARCHNames[ArchKind].DefaultFPU;
 
@@ -167,7 +167,7 @@ unsigned llvm::ARM::getDefaultFPU(StringRef CPU, unsigned ArchKind) {
     .Default(ARM::FK_INVALID);
 }
 
-unsigned llvm::ARM::getDefaultExtensions(StringRef CPU, unsigned ArchKind) {
+unsigned llvm_ks::ARM::getDefaultExtensions(StringRef CPU, unsigned ArchKind) {
   if (CPU == "generic")
     return ARCHNames[ArchKind].ArchBaseExtensions;
 
@@ -178,7 +178,7 @@ unsigned llvm::ARM::getDefaultExtensions(StringRef CPU, unsigned ArchKind) {
     .Default(ARM::AEK_INVALID);
 }
 
-bool llvm::ARM::getHWDivFeatures(unsigned HWDivKind,
+bool llvm_ks::ARM::getHWDivFeatures(unsigned HWDivKind,
                                  std::vector<const char *> &Features) {
 
   if (HWDivKind == ARM::AEK_INVALID)
@@ -197,7 +197,7 @@ bool llvm::ARM::getHWDivFeatures(unsigned HWDivKind,
   return true;
 }
 
-bool llvm::ARM::getExtensionFeatures(unsigned Extensions,
+bool llvm_ks::ARM::getExtensionFeatures(unsigned Extensions,
                                      std::vector<const char *> &Features) {
 
   if (Extensions == ARM::AEK_INVALID)
@@ -216,7 +216,7 @@ bool llvm::ARM::getExtensionFeatures(unsigned Extensions,
   return getHWDivFeatures(Extensions, Features);
 }
 
-bool llvm::ARM::getFPUFeatures(unsigned FPUKind,
+bool llvm_ks::ARM::getFPUFeatures(unsigned FPUKind,
                                std::vector<const char *> &Features) {
 
   if (FPUKind >= ARM::FK_LAST || FPUKind == ARM::FK_INVALID)
@@ -298,31 +298,31 @@ bool llvm::ARM::getFPUFeatures(unsigned FPUKind,
   return true;
 }
 
-StringRef llvm::ARM::getArchName(unsigned ArchKind) {
+StringRef llvm_ks::ARM::getArchName(unsigned ArchKind) {
   if (ArchKind >= ARM::AK_LAST)
     return StringRef();
   return ARCHNames[ArchKind].getName();
 }
 
-StringRef llvm::ARM::getCPUAttr(unsigned ArchKind) {
+StringRef llvm_ks::ARM::getCPUAttr(unsigned ArchKind) {
   if (ArchKind >= ARM::AK_LAST)
     return StringRef();
   return ARCHNames[ArchKind].getCPUAttr();
 }
 
-StringRef llvm::ARM::getSubArch(unsigned ArchKind) {
+StringRef llvm_ks::ARM::getSubArch(unsigned ArchKind) {
   if (ArchKind >= ARM::AK_LAST)
     return StringRef();
   return ARCHNames[ArchKind].getSubArch();
 }
 
-unsigned llvm::ARM::getArchAttr(unsigned ArchKind) {
+unsigned llvm_ks::ARM::getArchAttr(unsigned ArchKind) {
   if (ArchKind >= ARM::AK_LAST)
     return ARMBuildAttrs::CPUArch::Pre_v4;
   return ARCHNames[ArchKind].ArchAttr;
 }
 
-StringRef llvm::ARM::getArchExtName(unsigned ArchExtKind) {
+StringRef llvm_ks::ARM::getArchExtName(unsigned ArchExtKind) {
   for (const auto AE : ARCHExtNames) {
     if (ArchExtKind == AE.ID)
       return AE.getName();
@@ -330,7 +330,7 @@ StringRef llvm::ARM::getArchExtName(unsigned ArchExtKind) {
   return StringRef();
 }
 
-const char *llvm::ARM::getArchExtFeature(StringRef ArchExt) {
+const char *llvm_ks::ARM::getArchExtFeature(StringRef ArchExt) {
   if (ArchExt.startswith("no")) {
     StringRef ArchExtBase(ArchExt.substr(2));
     for (const auto AE : ARCHExtNames) {
@@ -346,7 +346,7 @@ const char *llvm::ARM::getArchExtFeature(StringRef ArchExt) {
   return nullptr;
 }
 
-StringRef llvm::ARM::getHWDivName(unsigned HWDivKind) {
+StringRef llvm_ks::ARM::getHWDivName(unsigned HWDivKind) {
   for (const auto D : HWDivNames) {
     if (HWDivKind == D.ID)
       return D.getName();
@@ -354,7 +354,7 @@ StringRef llvm::ARM::getHWDivName(unsigned HWDivKind) {
   return StringRef();
 }
 
-StringRef llvm::ARM::getDefaultCPU(StringRef Arch) {
+StringRef llvm_ks::ARM::getDefaultCPU(StringRef Arch) {
   unsigned AK = parseArch(Arch);
   if (AK == ARM::AK_INVALID)
     return StringRef();
@@ -420,7 +420,7 @@ static StringRef getArchSynonym(StringRef Arch) {
 // (iwmmxt|xscale)(eb)? is also permitted. If the former, return
 // "v.+", if the latter, return unmodified string, minus 'eb'.
 // If invalid, return empty string.
-StringRef llvm::ARM::getCanonicalArchName(StringRef Arch) {
+StringRef llvm_ks::ARM::getCanonicalArchName(StringRef Arch) {
   size_t offset = StringRef::npos;
   StringRef A = Arch;
   StringRef Error = "";
@@ -469,7 +469,7 @@ StringRef llvm::ARM::getCanonicalArchName(StringRef Arch) {
   return A;
 }
 
-unsigned llvm::ARM::parseHWDiv(StringRef HWDiv) {
+unsigned llvm_ks::ARM::parseHWDiv(StringRef HWDiv) {
   StringRef Syn = getHWDivSynonym(HWDiv);
   for (const auto D : HWDivNames) {
     if (Syn == D.getName())
@@ -478,7 +478,7 @@ unsigned llvm::ARM::parseHWDiv(StringRef HWDiv) {
   return ARM::AEK_INVALID;
 }
 
-unsigned llvm::ARM::parseFPU(StringRef FPU) {
+unsigned llvm_ks::ARM::parseFPU(StringRef FPU) {
   StringRef Syn = getFPUSynonym(FPU);
   for (const auto F : FPUNames) {
     if (Syn == F.getName())
@@ -488,7 +488,7 @@ unsigned llvm::ARM::parseFPU(StringRef FPU) {
 }
 
 // Allows partial match, ex. "v7a" matches "armv7a".
-unsigned llvm::ARM::parseArch(StringRef Arch) {
+unsigned llvm_ks::ARM::parseArch(StringRef Arch) {
   Arch = getCanonicalArchName(Arch);
   StringRef Syn = getArchSynonym(Arch);
   for (const auto A : ARCHNames) {
@@ -498,7 +498,7 @@ unsigned llvm::ARM::parseArch(StringRef Arch) {
   return ARM::AK_INVALID;
 }
 
-unsigned llvm::ARM::parseArchExt(StringRef ArchExt) {
+unsigned llvm_ks::ARM::parseArchExt(StringRef ArchExt) {
   for (const auto A : ARCHExtNames) {
     if (ArchExt == A.getName())
       return A.ID;
@@ -506,7 +506,7 @@ unsigned llvm::ARM::parseArchExt(StringRef ArchExt) {
   return ARM::AEK_INVALID;
 }
 
-unsigned llvm::ARM::parseCPUArch(StringRef CPU) {
+unsigned llvm_ks::ARM::parseCPUArch(StringRef CPU) {
   for (const auto C : CPUNames) {
     if (CPU == C.getName())
       return C.ArchID;
@@ -515,7 +515,7 @@ unsigned llvm::ARM::parseCPUArch(StringRef CPU) {
 }
 
 // ARM, Thumb, AArch64
-unsigned llvm::ARM::parseArchISA(StringRef Arch) {
+unsigned llvm_ks::ARM::parseArchISA(StringRef Arch) {
   return StringSwitch<unsigned>(Arch)
       .StartsWith("aarch64", ARM::IK_AARCH64)
       .StartsWith("arm64", ARM::IK_AARCH64)
@@ -525,7 +525,7 @@ unsigned llvm::ARM::parseArchISA(StringRef Arch) {
 }
 
 // Little/Big endian
-unsigned llvm::ARM::parseArchEndian(StringRef Arch) {
+unsigned llvm_ks::ARM::parseArchEndian(StringRef Arch) {
   if (Arch.startswith("armeb") || Arch.startswith("thumbeb") ||
       Arch.startswith("aarch64_be"))
     return ARM::EK_BIG;
@@ -544,7 +544,7 @@ unsigned llvm::ARM::parseArchEndian(StringRef Arch) {
 }
 
 // Profile A/R/M
-unsigned llvm::ARM::parseArchProfile(StringRef Arch) {
+unsigned llvm_ks::ARM::parseArchProfile(StringRef Arch) {
   Arch = getCanonicalArchName(Arch);
   switch (parseArch(Arch)) {
   case ARM::AK_ARMV6M:
@@ -566,7 +566,7 @@ unsigned llvm::ARM::parseArchProfile(StringRef Arch) {
 }
 
 // Version number (ex. v7 = 7).
-unsigned llvm::ARM::parseArchVersion(StringRef Arch) {
+unsigned llvm_ks::ARM::parseArchVersion(StringRef Arch) {
   Arch = getCanonicalArchName(Arch);
   switch (parseArch(Arch)) {
   case ARM::AK_ARMV2:

--- a/llvm/lib/Support/TargetRegistry.cpp
+++ b/llvm/lib/Support/TargetRegistry.cpp
@@ -13,7 +13,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <vector>
-using namespace llvm;
+using namespace llvm_ks;
 
 // Clients are responsible for avoid race conditions in registration.
 static Target *FirstTarget = nullptr;

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -15,7 +15,7 @@
 #include "llvm/Support/TargetParser.h"
 #include "llvm/Support/Host.h"
 #include <cstring>
-using namespace llvm;
+using namespace llvm_ks;
 
 const char *Triple::getArchTypeName(ArchType Kind) {
   switch (Kind) {
@@ -1086,57 +1086,57 @@ void Triple::setOSAndEnvironmentName(StringRef Str) {
   setTriple(getArchName() + "-" + getVendorName() + "-" + Str);
 }
 
-static unsigned getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
+static unsigned getArchPointerBitWidth(llvm_ks::Triple::ArchType Arch) {
   switch (Arch) {
-  case llvm::Triple::UnknownArch:
+  case llvm_ks::Triple::UnknownArch:
     return 0;
 
-  case llvm::Triple::avr:
-  case llvm::Triple::msp430:
+  case llvm_ks::Triple::avr:
+  case llvm_ks::Triple::msp430:
     return 16;
 
-  case llvm::Triple::arm:
-  case llvm::Triple::armeb:
-  case llvm::Triple::hexagon:
-  case llvm::Triple::le32:
-  case llvm::Triple::mips:
-  case llvm::Triple::mipsel:
-  case llvm::Triple::nvptx:
-  case llvm::Triple::ppc:
-  case llvm::Triple::r600:
-  case llvm::Triple::sparc:
-  case llvm::Triple::sparcel:
-  case llvm::Triple::tce:
-  case llvm::Triple::thumb:
-  case llvm::Triple::thumbeb:
-  case llvm::Triple::x86:
-  case llvm::Triple::xcore:
-  case llvm::Triple::amdil:
-  case llvm::Triple::hsail:
-  case llvm::Triple::spir:
-  case llvm::Triple::kalimba:
-  case llvm::Triple::shave:
-  case llvm::Triple::wasm32:
+  case llvm_ks::Triple::arm:
+  case llvm_ks::Triple::armeb:
+  case llvm_ks::Triple::hexagon:
+  case llvm_ks::Triple::le32:
+  case llvm_ks::Triple::mips:
+  case llvm_ks::Triple::mipsel:
+  case llvm_ks::Triple::nvptx:
+  case llvm_ks::Triple::ppc:
+  case llvm_ks::Triple::r600:
+  case llvm_ks::Triple::sparc:
+  case llvm_ks::Triple::sparcel:
+  case llvm_ks::Triple::tce:
+  case llvm_ks::Triple::thumb:
+  case llvm_ks::Triple::thumbeb:
+  case llvm_ks::Triple::x86:
+  case llvm_ks::Triple::xcore:
+  case llvm_ks::Triple::amdil:
+  case llvm_ks::Triple::hsail:
+  case llvm_ks::Triple::spir:
+  case llvm_ks::Triple::kalimba:
+  case llvm_ks::Triple::shave:
+  case llvm_ks::Triple::wasm32:
     return 32;
 
-  case llvm::Triple::aarch64:
-  case llvm::Triple::aarch64_be:
-  case llvm::Triple::amdgcn:
-  case llvm::Triple::bpfel:
-  case llvm::Triple::bpfeb:
-  case llvm::Triple::le64:
-  case llvm::Triple::mips64:
-  case llvm::Triple::mips64el:
-  case llvm::Triple::nvptx64:
-  case llvm::Triple::ppc64:
-  case llvm::Triple::ppc64le:
-  case llvm::Triple::sparcv9:
-  case llvm::Triple::systemz:
-  case llvm::Triple::x86_64:
-  case llvm::Triple::amdil64:
-  case llvm::Triple::hsail64:
-  case llvm::Triple::spir64:
-  case llvm::Triple::wasm64:
+  case llvm_ks::Triple::aarch64:
+  case llvm_ks::Triple::aarch64_be:
+  case llvm_ks::Triple::amdgcn:
+  case llvm_ks::Triple::bpfel:
+  case llvm_ks::Triple::bpfeb:
+  case llvm_ks::Triple::le64:
+  case llvm_ks::Triple::mips64:
+  case llvm_ks::Triple::mips64el:
+  case llvm_ks::Triple::nvptx64:
+  case llvm_ks::Triple::ppc64:
+  case llvm_ks::Triple::ppc64le:
+  case llvm_ks::Triple::sparcv9:
+  case llvm_ks::Triple::systemz:
+  case llvm_ks::Triple::x86_64:
+  case llvm_ks::Triple::amdil64:
+  case llvm_ks::Triple::hsail64:
+  case llvm_ks::Triple::spir64:
+  case llvm_ks::Triple::wasm64:
     return 64;
   }
   llvm_unreachable("Invalid architecture value");
@@ -1391,17 +1391,17 @@ StringRef Triple::getARMCPUForArch(StringRef MArch) const {
 
   // Some defaults are forced.
   switch (getOS()) {
-  case llvm::Triple::FreeBSD:
-  case llvm::Triple::NetBSD:
+  case llvm_ks::Triple::FreeBSD:
+  case llvm_ks::Triple::NetBSD:
     if (!MArch.empty() && MArch == "v6")
       return "arm1176jzf-s";
     break;
-  case llvm::Triple::Win32:
+  case llvm_ks::Triple::Win32:
     // FIXME: this is invalid for WindowsCE
     return "cortex-a9";
-  case llvm::Triple::MacOSX:
-  case llvm::Triple::IOS:
-  case llvm::Triple::WatchOS:
+  case llvm_ks::Triple::MacOSX:
+  case llvm_ks::Triple::IOS:
+  case llvm_ks::Triple::WatchOS:
     if (MArch == "v7k")
       return "cortex-a7";
     break;
@@ -1419,22 +1419,22 @@ StringRef Triple::getARMCPUForArch(StringRef MArch) const {
   // If no specific architecture version is requested, return the minimum CPU
   // required by the OS and environment.
   switch (getOS()) {
-  case llvm::Triple::NetBSD:
+  case llvm_ks::Triple::NetBSD:
     switch (getEnvironment()) {
-    case llvm::Triple::GNUEABIHF:
-    case llvm::Triple::GNUEABI:
-    case llvm::Triple::EABIHF:
-    case llvm::Triple::EABI:
+    case llvm_ks::Triple::GNUEABIHF:
+    case llvm_ks::Triple::GNUEABI:
+    case llvm_ks::Triple::EABIHF:
+    case llvm_ks::Triple::EABI:
       return "arm926ej-s";
     default:
       return "strongarm";
     }
-  case llvm::Triple::NaCl:
+  case llvm_ks::Triple::NaCl:
     return "cortex-a8";
   default:
     switch (getEnvironment()) {
-    case llvm::Triple::EABIHF:
-    case llvm::Triple::GNUEABIHF:
+    case llvm_ks::Triple::EABIHF:
+    case llvm_ks::Triple::GNUEABIHF:
       return "arm1176jzf-s";
     default:
       return "arm7tdmi";

--- a/llvm/lib/Support/Twine.cpp
+++ b/llvm/lib/Support/Twine.cpp
@@ -11,7 +11,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 std::string Twine::str() const {
   // If we're storing only a std::string, just return it.

--- a/llvm/lib/Support/Unix/Memory.inc
+++ b/llvm/lib/Support/Unix/Memory.inc
@@ -41,18 +41,18 @@ namespace {
 
 int getPosixProtectionFlags(unsigned Flags) {
   switch (Flags) {
-  case llvm::sys::Memory::MF_READ:
+  case llvm_ks::sys::Memory::MF_READ:
     return PROT_READ;
-  case llvm::sys::Memory::MF_WRITE:
+  case llvm_ks::sys::Memory::MF_WRITE:
     return PROT_WRITE;
-  case llvm::sys::Memory::MF_READ|llvm::sys::Memory::MF_WRITE:
+  case llvm_ks::sys::Memory::MF_READ|llvm_ks::sys::Memory::MF_WRITE:
     return PROT_READ | PROT_WRITE;
-  case llvm::sys::Memory::MF_READ|llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_READ|llvm_ks::sys::Memory::MF_EXEC:
     return PROT_READ | PROT_EXEC;
-  case llvm::sys::Memory::MF_READ | llvm::sys::Memory::MF_WRITE |
-      llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_READ | llvm_ks::sys::Memory::MF_WRITE |
+      llvm_ks::sys::Memory::MF_EXEC:
     return PROT_READ | PROT_WRITE | PROT_EXEC;
-  case llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_EXEC:
 #if defined(__FreeBSD__)
     // On PowerPC, having an executable page that has no read permission
     // can have unintended consequences.  The function InvalidateInstruction-
@@ -74,7 +74,7 @@ int getPosixProtectionFlags(unsigned Flags) {
 
 } // anonymous namespace
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
 MemoryBlock
@@ -305,4 +305,4 @@ void Memory::InvalidateInstructionCache(const void *Addr,
 }
 
 } // namespace sys
-} // namespace llvm
+} // namespace llvm_ks

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -60,9 +60,9 @@
 # define PATH_MAX 4096
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys  {
 namespace fs {
 #if defined(__FreeBSD__) || defined (__NetBSD__) || defined(__Bitrig__) || \
@@ -182,10 +182,10 @@ std::error_code current_path(SmallVectorImpl<char> &result) {
   result.clear();
 
   const char *pwd = ::getenv("PWD");
-  llvm::sys::fs::file_status PWDStatus, DotStatus;
-  if (pwd && llvm::sys::path::is_absolute(pwd) &&
-      !llvm::sys::fs::status(pwd, PWDStatus) &&
-      !llvm::sys::fs::status(".", DotStatus) &&
+  llvm_ks::sys::fs::file_status PWDStatus, DotStatus;
+  if (pwd && llvm_ks::sys::path::is_absolute(pwd) &&
+      !llvm_ks::sys::fs::status(pwd, PWDStatus) &&
+      !llvm_ks::sys::fs::status(".", DotStatus) &&
       PWDStatus.getUniqueID() == DotStatus.getUniqueID()) {
     result.append(pwd, pwd + strlen(pwd));
     return std::error_code();
@@ -623,4 +623,4 @@ void system_temp_directory(bool ErasedOnReboot, SmallVectorImpl<char> &Result) {
 } // end namespace path
 
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks

--- a/llvm/lib/Support/Unix/Process.inc
+++ b/llvm/lib/Support/Unix/Process.inc
@@ -55,7 +55,7 @@
 //===          is guaranteed to work on *all* UNIX variants.
 //===----------------------------------------------------------------------===//
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace sys;
 
 // On Cygwin, getpagesize() returns 64k(AllocationGranularity) and
@@ -357,7 +357,7 @@ const char *Process::ResetColor() {
   return "\033[0m";
 }
 
-unsigned llvm::sys::Process::GetRandomNumber() {
+unsigned llvm_ks::sys::Process::GetRandomNumber() {
 #if defined(HAVE_DECL_ARC4RANDOM) && HAVE_DECL_ARC4RANDOM
   return arc4random();
 #else

--- a/llvm/lib/Support/Unix/Unix.h
+++ b/llvm/lib/Support/Unix/Unix.h
@@ -61,7 +61,7 @@ static inline bool MakeErrMsg(
     return true;
   if (errnum == -1)
     errnum = errno;
-  *ErrMsg = prefix + ": ";  // + llvm::sys::StrError(errnum);
+  *ErrMsg = prefix + ": ";  // + llvm_ks::sys::StrError(errnum);
   return true;
 }
 

--- a/llvm/lib/Support/Windows/Memory.inc
+++ b/llvm/lib/Support/Windows/Memory.inc
@@ -25,20 +25,20 @@ DWORD getWindowsProtectionFlags(unsigned Flags) {
   switch (Flags) {
   // Contrary to what you might expect, the Windows page protection flags
   // are not a bitwise combination of RWX values
-  case llvm::sys::Memory::MF_READ:
+  case llvm_ks::sys::Memory::MF_READ:
     return PAGE_READONLY;
-  case llvm::sys::Memory::MF_WRITE:
+  case llvm_ks::sys::Memory::MF_WRITE:
     // Note: PAGE_WRITE is not supported by VirtualProtect
     return PAGE_READWRITE;
-  case llvm::sys::Memory::MF_READ|llvm::sys::Memory::MF_WRITE:
+  case llvm_ks::sys::Memory::MF_READ|llvm_ks::sys::Memory::MF_WRITE:
     return PAGE_READWRITE;
-  case llvm::sys::Memory::MF_READ|llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_READ|llvm_ks::sys::Memory::MF_EXEC:
     return PAGE_EXECUTE_READ;
-  case llvm::sys::Memory::MF_READ |
-         llvm::sys::Memory::MF_WRITE |
-         llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_READ |
+         llvm_ks::sys::Memory::MF_WRITE |
+         llvm_ks::sys::Memory::MF_EXEC:
     return PAGE_EXECUTE_READWRITE;
-  case llvm::sys::Memory::MF_EXEC:
+  case llvm_ks::sys::Memory::MF_EXEC:
     return PAGE_EXECUTE;
   default:
     llvm_unreachable("Illegal memory protection flag specified!");
@@ -58,7 +58,7 @@ size_t getAllocationGranularity() {
 
 } // namespace
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys {
 
 //===----------------------------------------------------------------------===//
@@ -240,4 +240,4 @@ bool Memory::setRangeExecutable(const void *Addr, size_t Size) {
 }
 
 } // namespace sys
-} // namespace llvm
+} // namespace llvm_ks

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -41,11 +41,11 @@ typedef int errno_t;
 # pragma comment(lib, "ole32.lib")     // This provides CoTaskMemFree
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 
-using llvm::sys::windows::UTF8ToUTF16;
-using llvm::sys::windows::UTF16ToUTF8;
-using llvm::sys::path::widenPath;
+using llvm_ks::sys::windows::UTF8ToUTF16;
+using llvm_ks::sys::windows::UTF16ToUTF8;
+using llvm_ks::sys::path::widenPath;
 
 static bool is_separator(const wchar_t value) {
   switch (value) {
@@ -57,7 +57,7 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
-namespace llvm {
+namespace llvm_ks {
 namespace sys  {
 namespace path {
 
@@ -75,7 +75,7 @@ std::error_code widenPath(const Twine &Path8,
 
   // If we made this path absolute, how much longer would it get?
   size_t CurPathLen;
-  if (llvm::sys::path::is_absolute(Twine(Path8Str)))
+  if (llvm_ks::sys::path::is_absolute(Twine(Path8Str)))
     CurPathLen = 0; // No contribution from current_path needed.
   else {
     CurPathLen = ::GetCurrentDirectoryW(0, NULL);
@@ -89,7 +89,7 @@ std::error_code widenPath(const Twine &Path8,
     SmallString<2*MAX_PATH> FullPath("\\\\?\\");
     if (CurPathLen) {
       SmallString<80> CurPath;
-      if (std::error_code EC = llvm::sys::fs::current_path(CurPath))
+      if (std::error_code EC = llvm_ks::sys::fs::current_path(CurPath))
         return EC;
       FullPath.append(CurPath);
     }
@@ -97,15 +97,15 @@ std::error_code widenPath(const Twine &Path8,
     // the \\?\ prefix is documented to treat them as real components).
     // The iterators don't report separators and append() always attaches
     // preferred_separator so we don't need to call native() on the result.
-    for (llvm::sys::path::const_iterator I = llvm::sys::path::begin(Path8Str),
-                                         E = llvm::sys::path::end(Path8Str);
+    for (llvm_ks::sys::path::const_iterator I = llvm_ks::sys::path::begin(Path8Str),
+                                         E = llvm_ks::sys::path::end(Path8Str);
                                          I != E; ++I) {
       if (I->size() == 1 && *I == ".")
         continue;
       if (I->size() == 2 && *I == "..")
-        llvm::sys::path::remove_filename(FullPath);
+        llvm_ks::sys::path::remove_filename(FullPath);
       else
-        llvm::sys::path::append(FullPath, *I);
+        llvm_ks::sys::path::append(FullPath, *I);
     }
     return UTF8ToUTF16(FullPath, Path16);
   }
@@ -799,8 +799,8 @@ void system_temp_directory(bool ErasedOnReboot, SmallVectorImpl<char> &Result) {
 } // end namespace path
 
 namespace windows {
-std::error_code UTF8ToUTF16(llvm::StringRef utf8,
-                            llvm::SmallVectorImpl<wchar_t> &utf16) {
+std::error_code UTF8ToUTF16(llvm_ks::StringRef utf8,
+                            llvm_ks::SmallVectorImpl<wchar_t> &utf16) {
   if (!utf8.empty()) {
     int len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.begin(),
                                     utf8.size(), utf16.begin(), 0);
@@ -828,7 +828,7 @@ std::error_code UTF8ToUTF16(llvm::StringRef utf8,
 static
 std::error_code UTF16ToCodePage(unsigned codepage, const wchar_t *utf16,
                                 size_t utf16_len,
-                                llvm::SmallVectorImpl<char> &utf8) {
+                                llvm_ks::SmallVectorImpl<char> &utf8) {
   if (utf16_len) {
     // Get length.
     int len = ::WideCharToMultiByte(codepage, 0, utf16, utf16_len, utf8.begin(),
@@ -856,14 +856,14 @@ std::error_code UTF16ToCodePage(unsigned codepage, const wchar_t *utf16,
 }
 
 std::error_code UTF16ToUTF8(const wchar_t *utf16, size_t utf16_len,
-                            llvm::SmallVectorImpl<char> &utf8) {
+                            llvm_ks::SmallVectorImpl<char> &utf8) {
   return UTF16ToCodePage(CP_UTF8, utf16, utf16_len, utf8);
 }
 
 std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
-                             llvm::SmallVectorImpl<char> &utf8) {
+                             llvm_ks::SmallVectorImpl<char> &utf8) {
   return UTF16ToCodePage(CP_ACP, utf16, utf16_len, utf8);
 }
 } // end namespace windows
 } // end namespace sys
-} // end namespace llvm
+} // end namespace llvm_ks

--- a/llvm/lib/Support/Windows/Process.inc
+++ b/llvm/lib/Support/Windows/Process.inc
@@ -46,7 +46,7 @@
 #  define _HEAPOK (-2)
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace sys;
 
 static TimeValue getTimeValueFromFILETIME(FILETIME Time) {
@@ -215,7 +215,7 @@ WildcardExpand(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
       break;
 
     // Push the filename onto Dir, and remove it afterwards.
-    llvm::sys::path::append(Dir, StringRef(FileName.data(), FileName.size()));
+    llvm_ks::sys::path::append(Dir, StringRef(FileName.data(), FileName.size()));
     AllocateAndPush(Dir, Args, Allocator);
     Dir.resize(DirSize);
   } while (FindNextFileW(FindHandle, &FileData));

--- a/llvm/lib/Support/Windows/WindowsSupport.h
+++ b/llvm/lib/Support/Windows/WindowsSupport.h
@@ -82,7 +82,7 @@ inline bool MakeErrMsg(std::string* ErrMsg, const std::string& prefix) {
     *ErrMsg = prefix + ": " + buffer;
   else
     *ErrMsg = prefix + ": Unknown error";
-  *ErrMsg += " (0x" + llvm::utohexstr(LastError) + ")";
+  *ErrMsg += " (0x" + llvm_ks::utohexstr(LastError) + ")";
 
   LocalFree(buffer);
   return R != 0;
@@ -182,7 +182,7 @@ typedef ScopedHandle<CryptContextTraits> ScopedCryptContext;
 typedef ScopedHandle<FindHandleTraits>   ScopedFindHandle;
 typedef ScopedHandle<JobHandleTraits>    ScopedJobHandle;
 
-namespace llvm {
+namespace llvm_ks {
 template <class T>
 class SmallVectorImpl;
 
@@ -209,6 +209,6 @@ std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
                              SmallVectorImpl<char> &utf8);
 } // end namespace windows
 } // end namespace sys
-} // end namespace llvm.
+} // end namespace llvm_ks.
 
 #endif

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -59,7 +59,7 @@
 #include "Windows/WindowsSupport.h"
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 
 raw_ostream::~raw_ostream() {
   // raw_ostream's subclasses should take care to flush the buffer
@@ -678,7 +678,7 @@ bool raw_fd_ostream::has_colors() const {
 
 /// outs() - This returns a reference to a raw_ostream for standard output.
 /// Use it like: outs() << "foo" << "bar";
-raw_ostream &llvm::outs() {
+raw_ostream &llvm_ks::outs() {
   // Set buffer settings to model stdout behavior.
   // Delete the file descriptor when the program exits, forcing error
   // detection. If you don't want this behavior, don't use outs().
@@ -690,14 +690,14 @@ raw_ostream &llvm::outs() {
 
 /// errs() - This returns a reference to a raw_ostream for standard error.
 /// Use it like: errs() << "foo" << "bar";
-raw_ostream &llvm::errs() {
+raw_ostream &llvm_ks::errs() {
   // Set standard error to be unbuffered by default.
   static raw_fd_ostream S(STDERR_FILENO, false, true);
   return S;
 }
 
 /// nulls() - This returns a reference to a raw_ostream which discards output.
-raw_ostream &llvm::nulls() {
+raw_ostream &llvm_ks::nulls() {
   static raw_null_ostream S;
   return S;
 }

--- a/llvm/lib/Target/AArch64/AArch64GenInstrInfo.inc
+++ b/llvm/lib/Target/AArch64/AArch64GenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace AArch64 {
   enum {
@@ -3335,7 +3335,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { AArch64::NZCV, 0 };
 static const MCPhysReg ImplicitList2[] = { AArch64::SP, 0 };
@@ -6491,7 +6491,7 @@ static inline void InitAArch64MCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct AArch64GenInstrInfo : public TargetInstrInfo {
   explicit AArch64GenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~AArch64GenInstrInfo() override {}
@@ -6502,7 +6502,7 @@ struct AArch64GenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace AArch64 {
 namespace OpName { 
 enum {
@@ -6510,23 +6510,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace AArch64
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace AArch64 {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace AArch64
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace AArch64 {
 namespace OpTypes { 
 enum OperandType {
@@ -6688,5 +6688,5 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace AArch64
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM

--- a/llvm/lib/Target/AArch64/AArch64GenRegisterInfo.inc
+++ b/llvm/lib/Target/AArch64/AArch64GenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass AArch64MCRegisterClasses[];
@@ -654,7 +654,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg AArch64RegDiffLists[] = {
   /* 0 */ 0, 1, 0,

--- a/llvm/lib/Target/AArch64/AArch64GenSubtargetInfo.inc
+++ b/llvm/lib/Target/AArch64/AArch64GenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace AArch64 {
 enum : uint64_t {
   FeatureCRC = 0,
@@ -38,9 +38,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV AArch64FeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV AArch64FeatureKV[] = {
   { "a35", "Cortex-A35 ARM processors", { AArch64::ProcA35 }, { AArch64::FeatureFPARMv8, AArch64::FeatureNEON, AArch64::FeatureCrypto, AArch64::FeatureCRC, AArch64::FeaturePerfMon } },
   { "a53", "Cortex-A53 ARM processors", { AArch64::ProcA53 }, { AArch64::FeatureFPARMv8, AArch64::FeatureNEON, AArch64::FeatureCrypto, AArch64::FeatureCRC, AArch64::FeaturePerfMon } },
   { "a57", "Cortex-A57 ARM processors", { AArch64::ProcA57 }, { AArch64::FeatureFPARMv8, AArch64::FeatureNEON, AArch64::FeatureCrypto, AArch64::FeatureCRC, AArch64::FeaturePerfMon } },
@@ -62,7 +62,7 @@ extern const llvm::SubtargetFeatureKV AArch64FeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV AArch64SubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV AArch64SubTypeKV[] = {
   { "cortex-a35", "Select the cortex-a35 processor", { AArch64::ProcA35 }, { } },
   { "cortex-a53", "Select the cortex-a53 processor", { AArch64::ProcA53 }, { } },
   { "cortex-a57", "Select the cortex-a57 processor", { AArch64::ProcA57 }, { } },
@@ -99,7 +99,7 @@ static inline MCSubtargetInfo *createAArch64MCSubtargetInfoImpl(const Triple &TT
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::AArch64Subtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::AArch64Subtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -37,7 +37,7 @@
 #include "keystone/arm64.h"
 
 #include <cstdio>
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AddressingModes.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// AArch64_AM - AArch64 Addressing Mode Stuff
 namespace AArch64_AM {
@@ -755,6 +755,6 @@ static inline uint64_t decodeAdvSIMDModImmType12(uint8_t Imm) {
 
 } // end namespace AArch64_AM
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -25,7 +25,7 @@
 
 #include <keystone/keystone.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -410,7 +410,7 @@ void ELFAArch64AsmBackend::processFixupValue(
 
 }
 
-MCAsmBackend *llvm::createAArch64leAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createAArch64leAsmBackend(const Target &T,
                                               const MCRegisterInfo &MRI,
                                               const Triple &TheTriple,
                                               StringRef CPU) {
@@ -419,7 +419,7 @@ MCAsmBackend *llvm::createAArch64leAsmBackend(const Target &T,
   return new ELFAArch64AsmBackend(T, OSABI, /*IsLittleEndian=*/true);
 }
 
-MCAsmBackend *llvm::createAArch64beAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createAArch64beAsmBackend(const Target &T,
                                               const MCRegisterInfo &MRI,
                                               const Triple &TheTriple,
                                               StringRef CPU) {

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -19,7 +19,7 @@
 #include "llvm/MC/MCValue.h"
 #include "llvm/Support/ErrorHandling.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 class AArch64ELFObjectWriter : public MCELFObjectTargetWriter {
@@ -249,7 +249,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
   llvm_unreachable("Unimplemented fixup -> relocation");
 }
 
-MCObjectWriter *llvm::createAArch64ELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createAArch64ELFObjectWriter(raw_pwrite_stream &OS,
                                                    uint8_t OSABI,
                                                    bool IsLittleEndian) {
   MCELFObjectTargetWriter *MOTW =

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.h
@@ -16,7 +16,7 @@
 
 #include "llvm/MC/MCELFStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 MCELFStreamer *createAArch64ELFStreamer(MCContext &Context, MCAsmBackend &TAB,
                                         raw_pwrite_stream &OS,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64FixupKinds.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64FixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace AArch64 {
 
 enum Fixups {
@@ -71,6 +71,6 @@ enum Fixups {
 };
 
 } // end namespace AArch64
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 enum AsmWriterVariantTy {
   Default = -1,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.h
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCStreamer;
 class Target;
 class Triple;
@@ -33,6 +33,6 @@ struct AArch64MCAsmInfoELF : public MCAsmInfoELF {
   explicit AArch64MCAsmInfoELF(const Triple &T);
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCCodeEmitter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCCodeEmitter.cpp
@@ -23,7 +23,7 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/raw_ostream.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -172,7 +172,7 @@ public:
 
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createAArch64MCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createAArch64MCCodeEmitter(const MCInstrInfo &MCII,
                                                 const MCRegisterInfo &MRI,
                                                 MCContext &Ctx) {
   return new AArch64MCCodeEmitter(MCII, Ctx);

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCExpr.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCExpr.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/Support/ErrorHandling.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "aarch64symbolrefexpr"
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCExpr.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCExpr.h
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class AArch64MCExpr : public MCTargetExpr {
 public:
@@ -162,6 +162,6 @@ public:
 
   static bool classof(const AArch64MCExpr *) { return true; }
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -22,7 +22,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "AArch64GenInstrInfo.inc"

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.h
@@ -17,7 +17,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class formatted_raw_ostream;
 class MCAsmBackend;
 class MCCodeEmitter;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.cpp
@@ -13,7 +13,7 @@
 
 #include "AArch64TargetStreamer.h"
 #include "llvm/MC/ConstantPools.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 //
 // AArch64TargetStreamer Implemenation

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.h
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64TargetStreamer.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class AArch64TargetStreamer : public MCTargetStreamer {
 public:
@@ -37,6 +37,6 @@ private:
   std::unique_ptr<AssemblerConstantPools> ConstantPools;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/AArch64/TargetInfo/AArch64TargetInfo.cpp
+++ b/llvm/lib/Target/AArch64/TargetInfo/AArch64TargetInfo.cpp
@@ -9,13 +9,13 @@
 
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-namespace llvm {
+namespace llvm_ks {
 Target TheAArch64leTarget;
 Target TheAArch64beTarget;
 Target TheARM64Target;
-} // end namespace llvm
+} // end namespace llvm_ks
 
 extern "C" void LLVMInitializeAArch64TargetInfo() {
   // Now register the "arm64" name for use with "-march". We don't want it to

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.cpp
@@ -16,7 +16,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Regex.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 StringRef AArch64NamedImmMapper::toString(uint32_t Value,
           const FeatureBitset& FeatureBits, bool &Valid) const {
@@ -268,7 +268,7 @@ const AArch64NamedImmMapper::Mapping AArch64SysReg::MRSMapper::MRSMappings[] = {
 
 AArch64SysReg::MRSMapper::MRSMapper() {
     InstMappings = &MRSMappings[0];
-    NumInstMappings = llvm::array_lengthof(MRSMappings);
+    NumInstMappings = llvm_ks::array_lengthof(MRSMappings);
 }
 
 const AArch64NamedImmMapper::Mapping AArch64SysReg::MSRMapper::MSRMappings[] = {
@@ -291,7 +291,7 @@ const AArch64NamedImmMapper::Mapping AArch64SysReg::MSRMapper::MSRMappings[] = {
 
 AArch64SysReg::MSRMapper::MSRMapper() {
     InstMappings = &MSRMappings[0];
-    NumInstMappings = llvm::array_lengthof(MSRMappings);
+    NumInstMappings = llvm_ks::array_lengthof(MSRMappings);
 }
 
 

--- a/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
+++ b/llvm/lib/Target/AArch64/Utils/AArch64BaseInfo.h
@@ -25,7 +25,7 @@
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 inline static unsigned getWRegFromXReg(unsigned Reg) {
   switch (Reg) {
@@ -1388,6 +1388,6 @@ namespace AArch64II {
   };
 } // end namespace AArch64II
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/ARMBaseRegisterInfo.h
+++ b/llvm/lib/Target/ARM/ARMBaseRegisterInfo.h
@@ -19,7 +19,7 @@
 #define GET_REGINFO_HEADER
 #include "ARMGenRegisterInfo.inc"
 
-namespace llvm {
+namespace llvm_ks {
 /// Register allocation hints.
 namespace ARMRI {
   enum {
@@ -194,6 +194,6 @@ public:
                       const TargetRegisterClass *NewRC) const override;
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/ARMFeatures.h
+++ b/llvm/lib/Target/ARM/ARMFeatures.h
@@ -16,7 +16,7 @@
 
 #include "MCTargetDesc/ARMMCTargetDesc.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 template<typename InstrType> // could be MachineInstr or MCInst
 bool IsCPSRDead(InstrType *Instr);

--- a/llvm/lib/Target/ARM/ARMGenInstrInfo.inc
+++ b/llvm/lib/Target/ARM/ARMGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace ARM {
   enum {
@@ -3656,7 +3656,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { ARM::CPSR, 0 };
 static const MCPhysReg ImplicitList2[] = { ARM::SP, 0 };
@@ -7060,7 +7060,7 @@ static inline void InitARMMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct ARMGenInstrInfo : public TargetInstrInfo {
   explicit ARMGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~ARMGenInstrInfo() override {}
@@ -7071,7 +7071,7 @@ struct ARMGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 namespace OpName { 
 enum {
@@ -7079,23 +7079,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace ARM
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace ARM
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 namespace OpTypes { 
 enum OperandType {
@@ -7294,5 +7294,5 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace ARM
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM

--- a/llvm/lib/Target/ARM/ARMGenRegisterInfo.inc
+++ b/llvm/lib/Target/ARM/ARMGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass ARMMCRegisterClasses[];
@@ -493,7 +493,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg ARMRegDiffLists[] = {
   /* 0 */ 64924, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,

--- a/llvm/lib/Target/ARM/ARMGenSubtargetInfo.inc
+++ b/llvm/lib/Target/ARM/ARMGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 enum : uint64_t {
   ARMv2 = 0,
@@ -124,9 +124,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV ARMFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV ARMFeatureKV[] = {
   { "32bit", "Prefer 32-bit Thumb instrs", { ARM::FeaturePref32BitThumb }, { } },
   { "8msecext", "Enable support for ARMv8-M Security Extensions", { ARM::Feature8MSecExt }, { } },
   { "a12", "Cortex-A12 ARM processors", { ARM::ProcA12 }, { } },
@@ -234,7 +234,7 @@ extern const llvm::SubtargetFeatureKV ARMFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV ARMSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV ARMSubTypeKV[] = {
   { "arm1020e", "Select the arm1020e processor", { ARM::ARMv5te }, { } },
   { "arm1020t", "Select the arm1020t processor", { ARM::ARMv5t }, { } },
   { "arm1022e", "Select the arm1022e processor", { ARM::ARMv5te }, { } },
@@ -350,7 +350,7 @@ static inline MCSubtargetInfo *createARMMCSubtargetInfoImpl(const Triple &TT, St
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::ARMSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::ARMSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
+++ b/llvm/lib/Target/ARM/AsmParser/ARMAsmParser.cpp
@@ -49,7 +49,7 @@
 
 #include "keystone/arm.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -8833,7 +8833,7 @@ unsigned ARMAsmParser::checkTargetMatchPredicate(MCInst &Inst) {
   return Match_Success;
 }
 
-namespace llvm {
+namespace llvm_ks {
 template <> inline bool IsCPSRDead<MCInst>(MCInst *Instr) {
   return true; // In an assembly source, no need to second-guess
 }

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAddressingModes.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAddressingModes.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// ARM_AM - ARM Addressing Mode Stuff
 namespace ARM_AM {
@@ -756,7 +756,7 @@ namespace ARM_AM {
   }
 
 } // end namespace ARM_AM
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -37,7 +37,7 @@
 
 #include <keystone/keystone.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 class ARMELFObjectWriter : public MCELFObjectTargetWriter {
@@ -884,7 +884,7 @@ enum CompactUnwindEncodings {
 
 } // end CU namespace
 
-MCAsmBackend *llvm::createARMAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createARMAsmBackend(const Target &T,
                                         const MCRegisterInfo &MRI,
                                         const Triple &TheTriple, StringRef CPU,
                                         bool isLittle) {
@@ -898,25 +898,25 @@ MCAsmBackend *llvm::createARMAsmBackend(const Target &T,
   }
 }
 
-MCAsmBackend *llvm::createARMLEAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createARMLEAsmBackend(const Target &T,
                                           const MCRegisterInfo &MRI,
                                           const Triple &TT, StringRef CPU) {
   return createARMAsmBackend(T, MRI, TT, CPU, true);
 }
 
-MCAsmBackend *llvm::createARMBEAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createARMBEAsmBackend(const Target &T,
                                           const MCRegisterInfo &MRI,
                                           const Triple &TT, StringRef CPU) {
   return createARMAsmBackend(T, MRI, TT, CPU, false);
 }
 
-MCAsmBackend *llvm::createThumbLEAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createThumbLEAsmBackend(const Target &T,
                                             const MCRegisterInfo &MRI,
                                             const Triple &TT, StringRef CPU) {
   return createARMAsmBackend(T, MRI, TT, CPU, true);
 }
 
-MCAsmBackend *llvm::createThumbBEAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createThumbBEAsmBackend(const Target &T,
                                             const MCRegisterInfo &MRI,
                                             const Triple &TT, StringRef CPU) {
   return createARMAsmBackend(T, MRI, TT, CPU, false);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.h
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/TargetRegistry.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class ARMAsmBackend : public MCAsmBackend {
   const MCSubtargetInfo *STI;
@@ -74,6 +74,6 @@ public:
   void setIsThumb(bool it) { isThumbMode = it; }
   bool isLittle() const { return IsLittleEndian; }
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackendELF.h
@@ -12,7 +12,7 @@
 
 #include "ARMAsmBackend.h"
 #include "MCTargetDesc/ARMMCTargetDesc.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 class ARMAsmBackendELF : public ARMAsmBackend {

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMBaseInfo.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMBaseInfo.h
@@ -20,7 +20,7 @@
 #include "ARMMCTargetDesc.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 // Enums corresponding to ARM condition codes
 namespace ARMCC {
@@ -459,6 +459,6 @@ namespace ARMII {
 
 } // end namespace ARMII
 
-} // end namespace llvm;
+} // end namespace llvm_ks;
 
 #endif

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFObjectWriter.cpp
@@ -18,7 +18,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
   class ARMELFObjectWriter : public MCELFObjectTargetWriter {
@@ -250,7 +250,7 @@ unsigned ARMELFObjectWriter::GetRelocTypeInner(const MCValue &Target,
   return Type;
 }
 
-MCObjectWriter *llvm::createARMELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createARMELFObjectWriter(raw_pwrite_stream &OS,
                                                uint8_t OSABI,
                                                bool IsLittleEndian) {
   MCELFObjectTargetWriter *MOTW = new ARMELFObjectWriter(OSABI);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMFixupKinds.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMFixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace ARM {
 enum Fixups {
   // fixup_arm_ldst_pcrel_12 - 12-bit PC relative relocation for symbol

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.cpp
@@ -14,7 +14,7 @@
 #include "ARMMCAsmInfo.h"
 #include "llvm/ADT/Triple.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 ARMMCAsmInfoDarwin::ARMMCAsmInfoDarwin(const Triple &TheTriple) {
   if ((TheTriple.getArch() == Triple::armeb) ||

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCAsmInfo.h
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class ARMMCAsmInfoDarwin : public MCAsmInfoDarwin {
@@ -43,6 +43,6 @@ public:
   explicit ARMCOFFMCAsmInfoGNU();
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
@@ -29,7 +29,7 @@
 
 #include "keystone/keystone.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -439,13 +439,13 @@ public:
 
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createARMLEMCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createARMLEMCCodeEmitter(const MCInstrInfo &MCII,
                                               const MCRegisterInfo &MRI,
                                               MCContext &Ctx) {
   return new ARMMCCodeEmitter(MCII, Ctx, true);
 }
 
-MCCodeEmitter *llvm::createARMBEMCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createARMBEMCCodeEmitter(const MCInstrInfo &MCII,
                                               const MCRegisterInfo &MRI,
                                               MCContext &Ctx) {
   return new ARMMCCodeEmitter(MCII, Ctx, false);

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCExpr.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCExpr.cpp
@@ -11,7 +11,7 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCStreamer.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "armmcexpr"
 

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCExpr.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCExpr.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCExpr.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class ARMMCExpr : public MCTargetExpr {
 public:
@@ -74,6 +74,6 @@ public:
     return E->getKind() == MCExpr::Target;
   }
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.cpp
@@ -24,14 +24,14 @@
 #include "llvm/Support/TargetParser.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_REGINFO_MC_DESC
 #include "ARMGenRegisterInfo.inc"
 
 static bool getMCRDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
                                   std::string &Info) {
-  if (STI.getFeatureBits()[llvm::ARM::HasV7Ops] &&
+  if (STI.getFeatureBits()[llvm_ks::ARM::HasV7Ops] &&
       (MI.getOperand(0).isImm() && MI.getOperand(0).getImm() == 15) &&
       (MI.getOperand(1).isImm() && MI.getOperand(1).getImm() == 0) &&
       // Checks for the deprecated CP15ISB encoding:
@@ -63,7 +63,7 @@ static bool getMCRDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
 
 static bool getITDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
                                  std::string &Info) {
-  if (STI.getFeatureBits()[llvm::ARM::HasV8Ops] && MI.getOperand(1).isImm() &&
+  if (STI.getFeatureBits()[llvm_ks::ARM::HasV8Ops] && MI.getOperand(1).isImm() &&
       MI.getOperand(1).getImm() != 8) {
     Info = "applying IT instruction to more than one subsequent instruction is "
            "deprecated";
@@ -75,7 +75,7 @@ static bool getITDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
 
 static bool getARMStoreDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
                                        std::string &Info) {
-  assert(!STI.getFeatureBits()[llvm::ARM::ModeThumb] &&
+  assert(!STI.getFeatureBits()[llvm_ks::ARM::ModeThumb] &&
          "cannot predicate thumb instructions");
 
   assert(MI.getNumOperands() >= 4 && "expected >= 4 arguments");
@@ -92,7 +92,7 @@ static bool getARMStoreDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
 
 static bool getARMLoadDeprecationInfo(MCInst &MI, const MCSubtargetInfo &STI,
                                       std::string &Info) {
-  assert(!STI.getFeatureBits()[llvm::ARM::ModeThumb] &&
+  assert(!STI.getFeatureBits()[llvm_ks::ARM::ModeThumb] &&
          "cannot predicate thumb instructions");
 
   assert(MI.getNumOperands() >= 4 && "expected >= 4 arguments");

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.h
@@ -18,7 +18,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class formatted_raw_ostream;
 class MCAsmBackend;
 class MCCodeEmitter;

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMTargetStreamer.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 //
 // ARMTargetStreamer Implemenation
 //

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMUnwindOpAsm.h
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMUnwindOpAsm.h
@@ -19,14 +19,14 @@
 #include "llvm/Support/ARMEHABI.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCSymbol;
 
 class UnwindOpcodeAssembler {
 private:
-  llvm::SmallVector<uint8_t, 32> Ops;
-  llvm::SmallVector<unsigned, 8> OpBegins;
+  llvm_ks::SmallVector<uint8_t, 32> Ops;
+  llvm_ks::SmallVector<unsigned, 8> OpBegins;
   bool HasPersonality;
 
 public:
@@ -88,6 +88,6 @@ private:
   }
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/ARM/TargetInfo/ARMTargetInfo.cpp
+++ b/llvm/lib/Target/ARM/TargetInfo/ARMTargetInfo.cpp
@@ -9,10 +9,10 @@
 
 #include "MCTargetDesc/ARMMCTargetDesc.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheARMLETarget,   llvm::TheARMBETarget;
-Target llvm::TheThumbLETarget, llvm::TheThumbBETarget;
+Target llvm_ks::TheARMLETarget,   llvm_ks::TheARMBETarget;
+Target llvm_ks::TheThumbLETarget, llvm_ks::TheThumbBETarget;
 
 extern "C" void LLVMInitializeARMTargetInfo() {
   RegisterTarget<Triple::arm>

--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -44,7 +44,7 @@
 
 #include "keystone/hexagon.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static bool WarnMissingParenthesis = true;
 static bool ErrorMissingParenthesis = false;
@@ -1323,7 +1323,7 @@ bool HexagonAsmParser::implicitExpressionLocation(OperandVector &Operands) {
 }
 
 bool HexagonAsmParser::parseExpression(MCExpr const *& Expr) {
-  llvm::SmallVector<AsmToken, 4> Tokens;
+  llvm_ks::SmallVector<AsmToken, 4> Tokens;
   MCAsmLexer &Lexer = getLexer();
   bool Done = false;
   static char const * Comma = ",";
@@ -1641,11 +1641,11 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
   case Hexagon::A2_tfrp: {
     MCOperand &MO = Inst.getOperand(1);
     unsigned int RegPairNum = RI->getEncodingValue(MO.getReg());
-    std::string R1 = r + llvm::utostr(RegPairNum + 1);
+    std::string R1 = r + llvm_ks::utostr(RegPairNum + 1);
     StringRef Reg1(R1);
     MO.setReg(MatchRegisterName(Reg1));
     // Add a new operand for the second register in the pair.
-    std::string R2 = r + llvm::utostr(RegPairNum);
+    std::string R2 = r + llvm_ks::utostr(RegPairNum);
     StringRef Reg2(R2);
     Inst.addOperand(MCOperand::createReg(MatchRegisterName(Reg2)));
     Inst.setOpcode(Hexagon::A2_combinew);
@@ -1656,11 +1656,11 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
   case Hexagon::A2_tfrpf: {
     MCOperand &MO = Inst.getOperand(2);
     unsigned int RegPairNum = RI->getEncodingValue(MO.getReg());
-    std::string R1 = r + llvm::utostr(RegPairNum + 1);
+    std::string R1 = r + llvm_ks::utostr(RegPairNum + 1);
     StringRef Reg1(R1);
     MO.setReg(MatchRegisterName(Reg1));
     // Add a new operand for the second register in the pair.
-    std::string R2 = r + llvm::utostr(RegPairNum);
+    std::string R2 = r + llvm_ks::utostr(RegPairNum);
     StringRef Reg2(R2);
     Inst.addOperand(MCOperand::createReg(MatchRegisterName(Reg2)));
     Inst.setOpcode((Inst.getOpcode() == Hexagon::A2_tfrpt)
@@ -1672,11 +1672,11 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
   case Hexagon::A2_tfrpfnew: {
     MCOperand &MO = Inst.getOperand(2);
     unsigned int RegPairNum = RI->getEncodingValue(MO.getReg());
-    std::string R1 = r + llvm::utostr(RegPairNum + 1);
+    std::string R1 = r + llvm_ks::utostr(RegPairNum + 1);
     StringRef Reg1(R1);
     MO.setReg(MatchRegisterName(Reg1));
     // Add a new operand for the second register in the pair.
-    std::string R2 = r + llvm::utostr(RegPairNum);
+    std::string R2 = r + llvm_ks::utostr(RegPairNum);
     StringRef Reg2(R2);
     Inst.addOperand(MCOperand::createReg(MatchRegisterName(Reg2)));
     Inst.setOpcode((Inst.getOpcode() == Hexagon::A2_tfrptnew)
@@ -1996,11 +1996,11 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (Value == 0) { // convert to $Rdd = combine ($Rs[0], $Rs[1])
       MCInst TmpInst;
       unsigned int RegPairNum = RI->getEncodingValue(Rss.getReg());
-      std::string R1 = r + llvm::utostr(RegPairNum + 1);
+      std::string R1 = r + llvm_ks::utostr(RegPairNum + 1);
       StringRef Reg1(R1);
       Rss.setReg(MatchRegisterName(Reg1));
       // Add a new operand for the second register in the pair.
-      std::string R2 = r + llvm::utostr(RegPairNum);
+      std::string R2 = r + llvm_ks::utostr(RegPairNum);
       StringRef Reg2(R2);
       TmpInst.setOpcode(Hexagon::A2_combinew);
       TmpInst.addOperand(Rdd);
@@ -2021,13 +2021,13 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (RegNum & 1) { // Odd mapped to raw:hi, regpair is rodd:odd-1, like r3:2
       Inst.setOpcode(Hexagon::A4_boundscheck_hi);
       std::string Name =
-          r + llvm::utostr(RegNum) + Colon + llvm::utostr(RegNum - 1);
+          r + llvm_ks::utostr(RegNum) + Colon + llvm_ks::utostr(RegNum - 1);
       StringRef RegPair = Name;
       Rs.setReg(MatchRegisterName(RegPair));
     } else { // raw:lo
       Inst.setOpcode(Hexagon::A4_boundscheck_lo);
       std::string Name =
-          r + llvm::utostr(RegNum + 1) + Colon + llvm::utostr(RegNum);
+          r + llvm_ks::utostr(RegNum + 1) + Colon + llvm_ks::utostr(RegNum);
       StringRef RegPair = Name;
       Rs.setReg(MatchRegisterName(RegPair));
     }
@@ -2040,13 +2040,13 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (RegNum & 1) { // Odd mapped to raw:hi
       Inst.setOpcode(Hexagon::A2_addsph);
       std::string Name =
-          r + llvm::utostr(RegNum) + Colon + llvm::utostr(RegNum - 1);
+          r + llvm_ks::utostr(RegNum) + Colon + llvm_ks::utostr(RegNum - 1);
       StringRef RegPair = Name;
       Rs.setReg(MatchRegisterName(RegPair));
     } else { // Even mapped raw:lo
       Inst.setOpcode(Hexagon::A2_addspl);
       std::string Name =
-          r + llvm::utostr(RegNum + 1) + Colon + llvm::utostr(RegNum);
+          r + llvm_ks::utostr(RegNum + 1) + Colon + llvm_ks::utostr(RegNum);
       StringRef RegPair = Name;
       Rs.setReg(MatchRegisterName(RegPair));
     }
@@ -2059,13 +2059,13 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (RegNum & 1) { // Odd mapped to sat:raw:hi
       Inst.setOpcode(Hexagon::M2_vrcmpys_s1_h);
       std::string Name =
-          r + llvm::utostr(RegNum) + Colon + llvm::utostr(RegNum - 1);
+          r + llvm_ks::utostr(RegNum) + Colon + llvm_ks::utostr(RegNum - 1);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     } else { // Even mapped sat:raw:lo
       Inst.setOpcode(Hexagon::M2_vrcmpys_s1_l);
       std::string Name =
-          r + llvm::utostr(RegNum + 1) + Colon + llvm::utostr(RegNum);
+          r + llvm_ks::utostr(RegNum + 1) + Colon + llvm_ks::utostr(RegNum);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     }
@@ -2081,13 +2081,13 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (RegNum & 1) { // Odd mapped to sat:raw:hi
       TmpInst.setOpcode(Hexagon::M2_vrcmpys_acc_s1_h);
       std::string Name =
-          r + llvm::utostr(RegNum) + Colon + llvm::utostr(RegNum - 1);
+          r + llvm_ks::utostr(RegNum) + Colon + llvm_ks::utostr(RegNum - 1);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     } else { // Even mapped sat:raw:lo
       TmpInst.setOpcode(Hexagon::M2_vrcmpys_acc_s1_l);
       std::string Name =
-          r + llvm::utostr(RegNum + 1) + Colon + llvm::utostr(RegNum);
+          r + llvm_ks::utostr(RegNum + 1) + Colon + llvm_ks::utostr(RegNum);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     }
@@ -2106,13 +2106,13 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (RegNum & 1) { // Odd mapped to rnd:sat:raw:hi
       Inst.setOpcode(Hexagon::M2_vrcmpys_s1rp_h);
       std::string Name =
-          r + llvm::utostr(RegNum) + Colon + llvm::utostr(RegNum - 1);
+          r + llvm_ks::utostr(RegNum) + Colon + llvm_ks::utostr(RegNum - 1);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     } else { // Even mapped rnd:sat:raw:lo
       Inst.setOpcode(Hexagon::M2_vrcmpys_s1rp_l);
       std::string Name =
-          r + llvm::utostr(RegNum + 1) + Colon + llvm::utostr(RegNum);
+          r + llvm_ks::utostr(RegNum + 1) + Colon + llvm_ks::utostr(RegNum);
       StringRef RegPair = Name;
       Rt.setReg(MatchRegisterName(RegPair));
     }
@@ -2146,11 +2146,11 @@ int HexagonAsmParser::processInstruction(MCInst &Inst,
     if (Value == 0) {
       MCInst TmpInst;
       unsigned int RegPairNum = RI->getEncodingValue(Rss.getReg());
-      std::string R1 = r + llvm::utostr(RegPairNum + 1);
+      std::string R1 = r + llvm_ks::utostr(RegPairNum + 1);
       StringRef Reg1(R1);
       Rss.setReg(MatchRegisterName(Reg1));
       // Add a new operand for the second register in the pair.
-      std::string R2 = r + llvm::utostr(RegPairNum);
+      std::string R2 = r + llvm_ks::utostr(RegPairNum);
       StringRef Reg2(R2);
       TmpInst.setOpcode(Hexagon::A2_combinew);
       TmpInst.addOperand(Rdd);

--- a/llvm/lib/Target/Hexagon/HexagonGenInstrInfo.inc
+++ b/llvm/lib/Target/Hexagon/HexagonGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace Hexagon {
   enum {
@@ -2666,7 +2666,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { Hexagon::USR_OVF, 0 };
 static const MCPhysReg ImplicitList2[] = { Hexagon::R31, Hexagon::R30, Hexagon::R29, 0 };
@@ -5532,7 +5532,7 @@ static inline void InitHexagonMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct HexagonGenInstrInfo : public TargetInstrInfo {
   explicit HexagonGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~HexagonGenInstrInfo() override {}
@@ -5543,7 +5543,7 @@ struct HexagonGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Hexagon {
 namespace OpName { 
 enum {
@@ -5551,23 +5551,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace Hexagon
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace Hexagon {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace Hexagon
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Hexagon {
 namespace OpTypes { 
 enum OperandType {
@@ -5661,11 +5661,11 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace Hexagon
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM
 #ifdef GET_INSTRMAP_INFO
 #undef GET_INSTRMAP_INFO
-namespace llvm {
+namespace llvm_ks {
 
 namespace Hexagon {
 

--- a/llvm/lib/Target/Hexagon/HexagonGenRegisterInfo.inc
+++ b/llvm/lib/Target/Hexagon/HexagonGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass HexagonMCRegisterClasses[];
@@ -198,7 +198,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg HexagonRegDiffLists[] = {
   /* 0 */ 0, 0,

--- a/llvm/lib/Target/Hexagon/HexagonGenSubtargetInfo.inc
+++ b/llvm/lib/Target/Hexagon/HexagonGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Hexagon {
 enum : uint64_t {
   ArchV4 = 0,
@@ -26,9 +26,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV HexagonFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV HexagonFeatureKV[] = {
   { "hvx", "Hexagon HVX instructions", { Hexagon::ExtensionHVX }, { } },
   { "hvx-double", "Hexagon HVX Double instructions", { Hexagon::ExtensionHVXDbl }, { } },
   { "v4", "Hexagon V4", { Hexagon::ArchV4 }, { } },
@@ -38,7 +38,7 @@ extern const llvm::SubtargetFeatureKV HexagonFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV HexagonSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV HexagonSubTypeKV[] = {
   { "hexagonv4", "Select the hexagonv4 processor", { Hexagon::ArchV4 }, { } },
   { "hexagonv5", "Select the hexagonv5 processor", { Hexagon::ArchV4, Hexagon::ArchV5 }, { } },
   { "hexagonv55", "Select the hexagonv55 processor", { Hexagon::ArchV4, Hexagon::ArchV5, Hexagon::ArchV55 }, { } },
@@ -90,66 +90,66 @@ namespace HexagonItinerariesV60FU {
   const unsigned CVI_ALL = 1 << 13;
 }
 
-extern const llvm::InstrStage HexagonStages[] = {
-  { 0, 0, 0, llvm::InstrStage::Required }, // No itinerary
-  { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 1
-  { 1, HexagonItinerariesV4FU::SLOT0 | HexagonItinerariesV4FU::SLOT1 | HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 2
-  { 1, HexagonItinerariesV4FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 3
-  { 1, HexagonItinerariesV4FU::SLOT2, -1, (llvm::InstrStage::ReservationKinds)0 }, // 4
-  { 1, HexagonItinerariesV4FU::SLOT0 | HexagonItinerariesV4FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 5
-  { 1, HexagonItinerariesV4FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 6
-  { 1, HexagonItinerariesV4FU::SLOT_ENDLOOP, -1, (llvm::InstrStage::ReservationKinds)0 }, // 7
-  { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 8-9
-  { 2, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 10
-  { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 11
-  { 1, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1 | HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 12
-  { 2, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1 | HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 13
-  { 3, HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 14
-  { 3, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 15
-  { 2, HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 16
-  { 2, HexagonItinerariesV55FU::SLOT2, -1, (llvm::InstrStage::ReservationKinds)0 }, // 17
-  { 3, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 18
-  { 1, HexagonItinerariesV55FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 19
-  { 2, HexagonItinerariesV55FU::SLOT_ENDLOOP, -1, (llvm::InstrStage::ReservationKinds)0 }, // 20
-  { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 21-22
-  { 3, HexagonItinerariesV55FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 23
-  { 2, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 24
-  { 1, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 25
-  { 2, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 26
-  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 27
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 28
-  { 2, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 29
-  { 3, HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 30
-  { 3, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 31
-  { 2, HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 32
-  { 2, HexagonItinerariesV60FU::SLOT2, -1, (llvm::InstrStage::ReservationKinds)0 }, // 33
-  { 3, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 34
-  { 1, HexagonItinerariesV60FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 35
-  { 2, HexagonItinerariesV60FU::SLOT_ENDLOOP, -1, (llvm::InstrStage::ReservationKinds)0 }, // 36
-  { 4, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 37
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 38-39
-  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm::InstrStage::ReservationKinds)0 }, // 40-41
-  { 4, HexagonItinerariesV60FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 42
-  { 2, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 43
-  { 3, HexagonItinerariesV60FU::SLOT0, -1, (llvm::InstrStage::ReservationKinds)0 }, // 44
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 45-47
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 48
-  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 49-51
-  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm::InstrStage::ReservationKinds)0 }, // 52-53
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLSHF | HexagonItinerariesV60FU::CVI_MPY01, -1, (llvm::InstrStage::ReservationKinds)0 }, // 54-55
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm::InstrStage::ReservationKinds)0 }, // 56-57
-  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT1, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm::InstrStage::ReservationKinds)0 }, // 58-61
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, -1, (llvm::InstrStage::ReservationKinds)0 }, // 62-63
-  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT1, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm::InstrStage::ReservationKinds)0 }, // 64-67
-  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, -1, (llvm::InstrStage::ReservationKinds)0 }, // 68-69
-  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_MPY01, -1, (llvm::InstrStage::ReservationKinds)0 }, // 70-71
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_SHIFT, -1, (llvm::InstrStage::ReservationKinds)0 }, // 72-73
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLSHF, -1, (llvm::InstrStage::ReservationKinds)0 }, // 74-75
-  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ALL, -1, (llvm::InstrStage::ReservationKinds)0 }, // 76-77
-  { 0, 0, 0, llvm::InstrStage::Required } // End stages
+extern const llvm_ks::InstrStage HexagonStages[] = {
+  { 0, 0, 0, llvm_ks::InstrStage::Required }, // No itinerary
+  { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 1
+  { 1, HexagonItinerariesV4FU::SLOT0 | HexagonItinerariesV4FU::SLOT1 | HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 2
+  { 1, HexagonItinerariesV4FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 3
+  { 1, HexagonItinerariesV4FU::SLOT2, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 4
+  { 1, HexagonItinerariesV4FU::SLOT0 | HexagonItinerariesV4FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 5
+  { 1, HexagonItinerariesV4FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 6
+  { 1, HexagonItinerariesV4FU::SLOT_ENDLOOP, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 7
+  { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV4FU::SLOT2 | HexagonItinerariesV4FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 8-9
+  { 2, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 10
+  { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 11
+  { 1, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1 | HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 12
+  { 2, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1 | HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 13
+  { 3, HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 14
+  { 3, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 15
+  { 2, HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 16
+  { 2, HexagonItinerariesV55FU::SLOT2, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 17
+  { 3, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 18
+  { 1, HexagonItinerariesV55FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 19
+  { 2, HexagonItinerariesV55FU::SLOT_ENDLOOP, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 20
+  { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV55FU::SLOT2 | HexagonItinerariesV55FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 21-22
+  { 3, HexagonItinerariesV55FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 23
+  { 2, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 24
+  { 1, HexagonItinerariesV55FU::SLOT0 | HexagonItinerariesV55FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 25
+  { 2, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 26
+  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 27
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 28
+  { 2, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 29
+  { 3, HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 30
+  { 3, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 31
+  { 2, HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 32
+  { 2, HexagonItinerariesV60FU::SLOT2, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 33
+  { 3, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 34
+  { 1, HexagonItinerariesV60FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 35
+  { 2, HexagonItinerariesV60FU::SLOT_ENDLOOP, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 36
+  { 4, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 37
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 38-39
+  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 40-41
+  { 4, HexagonItinerariesV60FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 42
+  { 2, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 43
+  { 3, HexagonItinerariesV60FU::SLOT0, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 44
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 45-47
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 48
+  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE | HexagonItinerariesV60FU::CVI_SHIFT | HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 49-51
+  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_MPY0 | HexagonItinerariesV60FU::CVI_MPY1, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 52-53
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLSHF | HexagonItinerariesV60FU::CVI_MPY01, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 54-55
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 56-57
+  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT1, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 58-61
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_LD, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 62-63
+  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::SLOT1, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLANE, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 64-67
+  { 1, HexagonItinerariesV60FU::SLOT0, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ST, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 68-69
+  { 1, HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_MPY01, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 70-71
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_SHIFT, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 72-73
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_XLSHF, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 74-75
+  { 1, HexagonItinerariesV60FU::SLOT0 | HexagonItinerariesV60FU::SLOT1 | HexagonItinerariesV60FU::SLOT2 | HexagonItinerariesV60FU::SLOT3, 0, (llvm_ks::InstrStage::ReservationKinds)0 },   { 1, HexagonItinerariesV60FU::CVI_ALL, -1, (llvm_ks::InstrStage::ReservationKinds)0 }, // 76-77
+  { 0, 0, 0, llvm_ks::InstrStage::Required } // End stages
 };
 
-static const llvm::InstrItinerary HexagonItinerariesV4[] = {
+static const llvm_ks::InstrItinerary HexagonItinerariesV4[] = {
   { 0, 0, 0, 0, 0 }, // 0 NoInstrModel
   { 1, 1, 2, 0, 0 }, // 1 S_2op_tc_2_SLOT23
   { 1, 1, 2, 0, 0 }, // 2 S_2op_tc_1_SLOT23
@@ -227,7 +227,7 @@ static const llvm::InstrItinerary HexagonItinerariesV4[] = {
   { 0, ~0U, ~0U, ~0U, ~0U } // end marker
 };
 
-static const llvm::InstrItinerary HexagonItinerariesV55[] = {
+static const llvm_ks::InstrItinerary HexagonItinerariesV55[] = {
   { 0, 0, 0, 0, 0 }, // 0 NoInstrModel
   { 1, 10, 11, 0, 0 }, // 1 S_2op_tc_2_SLOT23
   { 1, 11, 12, 0, 0 }, // 2 S_2op_tc_1_SLOT23
@@ -305,7 +305,7 @@ static const llvm::InstrItinerary HexagonItinerariesV55[] = {
   { 0, ~0U, ~0U, ~0U, ~0U } // end marker
 };
 
-static const llvm::InstrItinerary HexagonItinerariesV60[] = {
+static const llvm_ks::InstrItinerary HexagonItinerariesV60[] = {
   { 0, 0, 0, 0, 0 }, // 0 NoInstrModel
   { 1, 26, 27, 0, 0 }, // 1 S_2op_tc_2_SLOT23
   { 1, 27, 28, 0, 0 }, // 2 S_2op_tc_1_SLOT23
@@ -386,7 +386,7 @@ static const llvm::InstrItinerary HexagonItinerariesV60[] = {
 // ===============================================================
 // Data tables for the new per-operand machine model.
 
-static const llvm::MCSchedModel HexagonModelV4 = {
+static const llvm_ks::MCSchedModel HexagonModelV4 = {
   4, // IssueWidth
   MCSchedModel::DefaultMicroOpBufferSize,
   MCSchedModel::DefaultLoopMicroOpBufferSize,
@@ -399,7 +399,7 @@ static const llvm::MCSchedModel HexagonModelV4 = {
   nullptr, nullptr, 0, 0, // No instruction-level machine model.
   HexagonItinerariesV4};
 
-static const llvm::MCSchedModel HexagonModelV55 = {
+static const llvm_ks::MCSchedModel HexagonModelV55 = {
   4, // IssueWidth
   MCSchedModel::DefaultMicroOpBufferSize,
   MCSchedModel::DefaultLoopMicroOpBufferSize,
@@ -412,7 +412,7 @@ static const llvm::MCSchedModel HexagonModelV55 = {
   nullptr, nullptr, 0, 0, // No instruction-level machine model.
   HexagonItinerariesV55};
 
-static const llvm::MCSchedModel HexagonModelV60 = {
+static const llvm_ks::MCSchedModel HexagonModelV60 = {
   4, // IssueWidth
   MCSchedModel::DefaultMicroOpBufferSize,
   MCSchedModel::DefaultLoopMicroOpBufferSize,
@@ -426,7 +426,7 @@ static const llvm::MCSchedModel HexagonModelV60 = {
   HexagonItinerariesV60};
 
 // Sorted (by key) array of itineraries for CPU subtype.
-extern const llvm::SubtargetInfoKV HexagonProcSchedKV[] = {
+extern const llvm_ks::SubtargetInfoKV HexagonProcSchedKV[] = {
   { "hexagonv4", (const void *)&HexagonModelV4 },
   { "hexagonv5", (const void *)&HexagonModelV4 },
   { "hexagonv55", (const void *)&HexagonModelV55 },
@@ -448,7 +448,7 @@ static inline MCSubtargetInfo *createHexagonMCSubtargetInfoImpl(const Triple &TT
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::HexagonSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::HexagonSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/Hexagon/HexagonTargetStreamer.h
+++ b/llvm/lib/Target/Hexagon/HexagonTargetStreamer.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 class HexagonTargetStreamer : public MCTargetStreamer {
 public:
   HexagonTargetStreamer(MCStreamer &S) : MCTargetStreamer(S) {}

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonAsmBackend.cpp
@@ -23,7 +23,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace Hexagon;
 
 #define DEBUG_TYPE "hexagon-asm-backend"
@@ -182,10 +182,10 @@ public:
     const MCInstrDesc &MCID = HexagonMCInstrInfo::getDesc(*MCII, HMI);
     bool Relaxable = false;
     // Branches and loop-setup insns are handled as necessary by relaxation.
-    if (llvm::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeJ ||
-        (llvm::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeNV &&
+    if (llvm_ks::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeJ ||
+        (llvm_ks::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeNV &&
          MCID.isBranch()) ||
-        (llvm::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeCR &&
+        (llvm_ks::HexagonMCInstrInfo::getType(*MCII, HMI) == HexagonII::TypeCR &&
          HMI.getOpcode() != Hexagon::C4_addipc))
       if (HexagonMCInstrInfo::isExtendable(*MCII, HMI))
         Relaxable = true;
@@ -351,7 +351,7 @@ public:
 };
 } // end anonymous namespace
 
-namespace llvm {
+namespace llvm_ks {
 MCAsmBackend *createHexagonAsmBackend(Target const &T,
                                       MCRegisterInfo const & /*MRI*/,
                                       const Triple &TT, StringRef CPU) {

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonBaseInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonBaseInfo.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <stdint.h>
 
-namespace llvm {
+namespace llvm_ks {
 
 /// HexagonII - This namespace holds all of the target specific flags that
 /// instruction info tracks.
@@ -280,6 +280,6 @@ namespace HexagonII {
 
 } // End namespace HexagonII.
 
-} // End namespace llvm.
+} // End namespace llvm_ks.
 
 #endif

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonELFObjectWriter.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonELFObjectWriter.cpp
@@ -16,7 +16,7 @@
 
 #define DEBUG_TYPE "hexagon-elf-writer"
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace Hexagon;
 
 namespace {
@@ -244,7 +244,7 @@ unsigned HexagonELFObjectWriter::getRelocType(MCContext &Ctx,
   }
 }
 
-MCObjectWriter *llvm::createHexagonELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createHexagonELFObjectWriter(raw_pwrite_stream &OS,
                                                    uint8_t OSABI,
                                                    StringRef CPU) {
   MCELFObjectTargetWriter *MOTW = new HexagonELFObjectWriter(OSABI, CPU);

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonFixupKinds.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonFixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace Hexagon {
 enum Fixups {
   // Branch fixups for R_HEX_B{22,15,7}_PCREL.
@@ -132,6 +132,6 @@ enum FixupBitmaps : unsigned {
   Word32_X26 = 0x0fff3fff
 };
 } // namespace Hexagon
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif // LLVM_HEXAGON_HEXAGONFIXUPKINDS_H

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.cpp
@@ -13,7 +13,7 @@
 
 #include "HexagonMCAsmInfo.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 HexagonMCAsmInfo::HexagonMCAsmInfo(const Triple &TT) {
   Data16bitsDirective = "\t.half\t";

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCAsmInfo.h
@@ -17,7 +17,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class HexagonMCAsmInfo : public MCAsmInfoELF {
@@ -25,6 +25,6 @@ public:
   explicit HexagonMCAsmInfo(const Triple &TT);
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCChecker.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCChecker.cpp
@@ -22,7 +22,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static bool RelaxNVChecks = false;
 
@@ -143,19 +143,19 @@ void HexagonMCChecker::init(MCInst const& MCI) {
       else if (HexagonMCInstrInfo::isPredicateLate(MCII, MCI) && isPredicateRegister(*SRI))
         // Some insns produce predicates too late to be used in the same packet.
         LatePreds.insert(*SRI);
-      else if (i == 0 && llvm::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeCVI_VM_CUR_LD)
+      else if (i == 0 && llvm_ks::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeCVI_VM_CUR_LD)
         // Current loads should be used in the same packet.
         // TODO: relies on the impossibility of a current and a temporary loads
         // in the same packet.
         CurDefs.insert(*SRI), Defs[*SRI].insert(PredSense(PredReg, isTrue));
-      else if (i == 0 && llvm::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeCVI_VM_TMP_LD)
+      else if (i == 0 && llvm_ks::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeCVI_VM_TMP_LD)
         // Temporary loads should be used in the same packet, but don't commit
         // results, so it should be disregarded if another insn changes the same
         // register.
         // TODO: relies on the impossibility of a current and a temporary loads
         // in the same packet.
         TmpDefs.insert(*SRI);
-      else if (i <= 1 && llvm::HexagonMCInstrInfo::hasNewValue2(MCII, MCI) )
+      else if (i <= 1 && llvm_ks::HexagonMCInstrInfo::hasNewValue2(MCII, MCI) )
         // vshuff(Vx, Vy, Rx) <- Vx(0) and Vy(1) are both source and
         // destination registers with this instruction. same for vdeal(Vx,Vy,Rx)
         Uses.insert(*SRI);
@@ -210,7 +210,7 @@ void HexagonMCChecker::init(MCInst const& MCI) {
     if (!MCSubRegIterator(N, &RI).isValid()) {
       // Super-registers cannot use new values.
       if (MCID.isBranch())
-        NewUses[N] = NewSense::Jmp(llvm::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeNV);
+        NewUses[N] = NewSense::Jmp(llvm_ks::HexagonMCInstrInfo::getType(MCII, MCI) == HexagonII::TypeNV);
       else
         NewUses[N] = NewSense::Use(PredReg, HexagonMCInstrInfo::isPredicatedTrue(MCII, MCI));
     }
@@ -460,7 +460,7 @@ bool HexagonMCChecker::checkRegisters() {
       // special case for vhist
       bool vHistFound = false;
       for (auto const&HMI : HexagonMCInstrInfo::bundleInstructions(MCB)) {
-        if(llvm::HexagonMCInstrInfo::getType(MCII, *HMI.getInst()) == HexagonII::TypeCVI_HIST) {
+        if(llvm_ks::HexagonMCInstrInfo::getType(MCII, *HMI.getInst()) == HexagonII::TypeCVI_HIST) {
           vHistFound = true;  // vhist() implicitly uses ALL REGxx.tmp
           break;
         }
@@ -483,7 +483,7 @@ bool HexagonMCChecker::checkSolo() {
   if (HexagonMCInstrInfo::isBundle(MCB) &&
       HexagonMCInstrInfo::bundleSize(MCB) > 1) {
     for (auto const&I : HexagonMCInstrInfo::bundleInstructions(MCB)) {
-      if (llvm::HexagonMCInstrInfo::isSolo(MCII, *I.getInst())) {
+      if (llvm_ks::HexagonMCInstrInfo::isSolo(MCII, *I.getInst())) {
         errInfo.setError(HexagonMCErrInfo::CHECK_ERROR_SOLO);
         addErrInfo(errInfo);
         return false;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCChecker.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCChecker.h
@@ -20,9 +20,9 @@
 #include <queue>
 #include "MCTargetDesc/HexagonMCShuffler.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
-namespace llvm {
+namespace llvm_ks {
 class MCOperandInfo;
 
 typedef struct {
@@ -85,8 +85,8 @@ class HexagonMCChecker {
   typedef std::multiset<PredSense> PredSet;
   typedef std::multiset<PredSense>::iterator PredSetIterator;
 
-  typedef llvm::DenseMap<unsigned, PredSet>::iterator DefsIterator;
-  llvm::DenseMap<unsigned, PredSet> Defs;
+  typedef llvm_ks::DenseMap<unsigned, PredSet>::iterator DefsIterator;
+  llvm_ks::DenseMap<unsigned, PredSet> Defs;
 
   /// Information about how a new-value register is defined or used:
   ///   PredReg = predicate register, 0 if use/def not predicated,
@@ -116,9 +116,9 @@ class HexagonMCChecker {
     }
   };
   /// Set of definitions that produce new register:
-  typedef llvm::SmallVector<NewSense,2> NewSenseList;
-  typedef llvm::DenseMap<unsigned, NewSenseList>::iterator NewDefsIterator;
-  llvm::DenseMap<unsigned, NewSenseList> NewDefs;
+  typedef llvm_ks::SmallVector<NewSense,2> NewSenseList;
+  typedef llvm_ks::DenseMap<unsigned, NewSenseList>::iterator NewDefsIterator;
+  llvm_ks::DenseMap<unsigned, NewSenseList> NewDefs;
 
   /// Set of weak definitions whose clashes should be enforced selectively.
   typedef std::set<unsigned>::iterator SoftDefsIterator;
@@ -145,8 +145,8 @@ class HexagonMCChecker {
   std::set<unsigned> Uses;
 
   /// Set of new values used: new register, if new-value jump.
-  typedef llvm::DenseMap<unsigned, NewSense>::iterator NewUsesIterator;
-  llvm::DenseMap<unsigned, NewSense> NewUses;
+  typedef llvm_ks::DenseMap<unsigned, NewSense>::iterator NewUsesIterator;
+  llvm_ks::DenseMap<unsigned, NewSense> NewUses;
 
   /// Pre-defined set of read-only registers.
   typedef std::set<unsigned>::iterator ReadOnlyIterator;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCodeEmitter.cpp
@@ -28,7 +28,7 @@
 
 #define DEBUG_TYPE "mccodeemitter"
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace Hexagon;
 
 
@@ -119,7 +119,7 @@ void HexagonMCCodeEmitter::EncodeSingleInstruction(
                   " `" << HexagonMCInstrInfo::getName(MCII, HMB) << "'"
                                                                     "\n");
 
-  if (llvm::HexagonMCInstrInfo::getType(MCII, HMB) == HexagonII::TypeCOMPOUND) {
+  if (llvm_ks::HexagonMCInstrInfo::getType(MCII, HMB) == HexagonII::TypeCOMPOUND) {
     for (unsigned i = 0; i < HMB.getNumOperands(); ++i)
       if (HMB.getOperand(i).isReg()) {
         unsigned Reg =
@@ -273,25 +273,25 @@ static Hexagon::Fixups getFixupNoBits(MCInstrInfo const &MCII, const MCInst &MI,
                                       const MCOperand &MO,
                                       const MCSymbolRefExpr::VariantKind kind) {
   const MCInstrDesc &MCID = HexagonMCInstrInfo::getDesc(MCII, MI);
-  unsigned insnType = llvm::HexagonMCInstrInfo::getType(MCII, MI);
+  unsigned insnType = llvm_ks::HexagonMCInstrInfo::getType(MCII, MI);
 
   if (insnType == HexagonII::TypePREFIX) {
     switch (kind) {
-    case llvm::MCSymbolRefExpr::VK_GOTOFF:
+    case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
       return Hexagon::fixup_Hexagon_GOTREL_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_GOT:
       return Hexagon::fixup_Hexagon_GOT_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_TPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_TPREL:
       return Hexagon::fixup_Hexagon_TPREL_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_DTPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
       return Hexagon::fixup_Hexagon_DTPREL_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
       return Hexagon::fixup_Hexagon_GD_GOT_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
       return Hexagon::fixup_Hexagon_LD_GOT_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE:
       return Hexagon::fixup_Hexagon_IE_32_6_X;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
       return Hexagon::fixup_Hexagon_IE_GOT_32_6_X;
     default:
       if (MCID.isBranch())
@@ -306,21 +306,21 @@ static Hexagon::Fixups getFixupNoBits(MCInstrInfo const &MCII, const MCInst &MI,
   case Hexagon::HI:
   case Hexagon::A2_tfrih:
     switch (kind) {
-    case llvm::MCSymbolRefExpr::VK_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_GOT:
       return Hexagon::fixup_Hexagon_GOT_HI16;
-    case llvm::MCSymbolRefExpr::VK_GOTOFF:
+    case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
       return Hexagon::fixup_Hexagon_GOTREL_HI16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
       return Hexagon::fixup_Hexagon_GD_GOT_HI16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
       return Hexagon::fixup_Hexagon_LD_GOT_HI16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE:
       return Hexagon::fixup_Hexagon_IE_HI16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
       return Hexagon::fixup_Hexagon_IE_GOT_HI16;
-    case llvm::MCSymbolRefExpr::VK_TPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_TPREL:
       return Hexagon::fixup_Hexagon_TPREL_HI16;
-    case llvm::MCSymbolRefExpr::VK_DTPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
       return Hexagon::fixup_Hexagon_DTPREL_HI16;
     default:
       return Hexagon::fixup_Hexagon_HI16;
@@ -329,21 +329,21 @@ static Hexagon::Fixups getFixupNoBits(MCInstrInfo const &MCII, const MCInst &MI,
   case Hexagon::LO:
   case Hexagon::A2_tfril:
     switch (kind) {
-    case llvm::MCSymbolRefExpr::VK_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_GOT:
       return Hexagon::fixup_Hexagon_GOT_LO16;
-    case llvm::MCSymbolRefExpr::VK_GOTOFF:
+    case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
       return Hexagon::fixup_Hexagon_GOTREL_LO16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
       return Hexagon::fixup_Hexagon_GD_GOT_LO16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
       return Hexagon::fixup_Hexagon_LD_GOT_LO16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE:
       return Hexagon::fixup_Hexagon_IE_LO16;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
       return Hexagon::fixup_Hexagon_IE_GOT_LO16;
-    case llvm::MCSymbolRefExpr::VK_TPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_TPREL:
       return Hexagon::fixup_Hexagon_TPREL_LO16;
-    case llvm::MCSymbolRefExpr::VK_DTPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
       return Hexagon::fixup_Hexagon_DTPREL_LO16;
     default:
       return Hexagon::fixup_Hexagon_LO16;
@@ -376,7 +376,7 @@ static Hexagon::Fixups getFixupNoBits(MCInstrInfo const &MCII, const MCInst &MI,
   return LastTargetFixupKind;
 }
 
-namespace llvm {
+namespace llvm_ks {
 extern const MCInstrDesc HexagonInsts[];
 }
 
@@ -460,38 +460,38 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
 
   case 32:
     switch (kind) {
-    case llvm::MCSymbolRefExpr::VK_Hexagon_PCREL:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_PCREL:
       FixupKind = Hexagon::fixup_Hexagon_32_PCREL;
       break;
-    case llvm::MCSymbolRefExpr::VK_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_GOT:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_GOT_32_6_X
                             : Hexagon::fixup_Hexagon_GOT_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_GOTOFF:
+    case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_GOTREL_32_6_X
                             : Hexagon::fixup_Hexagon_GOTREL_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_GD_GOT_32_6_X
                             : Hexagon::fixup_Hexagon_GD_GOT_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_LD_GOT_32_6_X
                             : Hexagon::fixup_Hexagon_LD_GOT_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_IE_32_6_X
                             : Hexagon::fixup_Hexagon_IE_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_IE_GOT_32_6_X
                             : Hexagon::fixup_Hexagon_IE_GOT_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_TPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_TPREL:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_TPREL_32_6_X
                             : Hexagon::fixup_Hexagon_TPREL_32;
       break;
-    case llvm::MCSymbolRefExpr::VK_DTPREL:
+    case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_DTPREL_32_6_X
                             : Hexagon::fixup_Hexagon_DTPREL_32;
       break;
@@ -504,10 +504,10 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
 
   case 22:
     switch (kind) {
-    case llvm::MCSymbolRefExpr::VK_Hexagon_GD_PLT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_PLT:
       FixupKind = Hexagon::fixup_Hexagon_GD_PLT_B22_PCREL;
       break;
-    case llvm::MCSymbolRefExpr::VK_Hexagon_LD_PLT:
+    case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_PLT:
       FixupKind = Hexagon::fixup_Hexagon_LD_PLT_B22_PCREL;
       break;
     default:
@@ -528,28 +528,28 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
       default:
         FixupKind = Hexagon::fixup_Hexagon_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GOT_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOTOFF:
+      case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
         FixupKind = Hexagon::fixup_Hexagon_GOTREL_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GD_GOT_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_LD_GOT_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_IE:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE:
         FixupKind = Hexagon::fixup_Hexagon_IE_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
         FixupKind = Hexagon::fixup_Hexagon_IE_GOT_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_TPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_TPREL:
         FixupKind = Hexagon::fixup_Hexagon_TPREL_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_DTPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
         FixupKind = Hexagon::fixup_Hexagon_DTPREL_16_X;
         break;
       }
@@ -559,35 +559,35 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
         errs() << "unrecognized relocation, bits " << bits << "\n";
         errs() << "name = " << HexagonMCInstrInfo::getName(MCII, MI) << "\n";
         break;
-      case llvm::MCSymbolRefExpr::VK_GOTOFF:
+      case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
         if ((MCID.getOpcode() == Hexagon::HI) ||
             (MCID.getOpcode() == Hexagon::LO_H))
           FixupKind = Hexagon::fixup_Hexagon_GOTREL_HI16;
         else
           FixupKind = Hexagon::fixup_Hexagon_GOTREL_LO16;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_GPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GPREL:
         FixupKind = Hexagon::fixup_Hexagon_GPREL16_0;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_LO16:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LO16:
         FixupKind = Hexagon::fixup_Hexagon_LO16;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_HI16:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_HI16:
         FixupKind = Hexagon::fixup_Hexagon_HI16;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GD_GOT_16;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_LD_GOT_16;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
         FixupKind = Hexagon::fixup_Hexagon_IE_GOT_16;
         break;
-      case llvm::MCSymbolRefExpr::VK_TPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_TPREL:
         FixupKind = Hexagon::fixup_Hexagon_TPREL_16;
         break;
-      case llvm::MCSymbolRefExpr::VK_DTPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
         FixupKind = Hexagon::fixup_Hexagon_DTPREL_16;
         break;
       }
@@ -615,10 +615,10 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
         FixupKind = Hexagon::fixup_Hexagon_12_X;
         break;
       // There isn't a GOT_12_X, both 11_X and 16_X resolve to 6/26
-      case llvm::MCSymbolRefExpr::VK_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GOT_16_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOTOFF:
+      case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
         FixupKind = Hexagon::fixup_Hexagon_GOTREL_16_X;
         break;
       }
@@ -634,25 +634,25 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
       default:
         FixupKind = Hexagon::fixup_Hexagon_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GOT_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOTOFF:
+      case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
         FixupKind = Hexagon::fixup_Hexagon_GOTREL_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_GD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GD_GOT_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_LD_GOT:
         FixupKind = Hexagon::fixup_Hexagon_LD_GOT_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_IE_GOT:
         FixupKind = Hexagon::fixup_Hexagon_IE_GOT_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_TPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_TPREL:
         FixupKind = Hexagon::fixup_Hexagon_TPREL_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_DTPREL:
+      case llvm_ks::MCSymbolRefExpr::VK_DTPREL:
         FixupKind = Hexagon::fixup_Hexagon_DTPREL_11_X;
         break;
       }
@@ -669,7 +669,7 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
 
   case 9:
     if (MCID.isBranch() ||
-        (llvm::HexagonMCInstrInfo::getType(MCII, MI) == HexagonII::TypeCR))
+        (llvm_ks::HexagonMCInstrInfo::getType(MCII, MI) == HexagonII::TypeCR))
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_B9_PCREL_X
                             : Hexagon::fixup_Hexagon_B9_PCREL;
     else if (*Extended)
@@ -691,7 +691,7 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
 
   case 7:
     if (MCID.isBranch() ||
-        (llvm::HexagonMCInstrInfo::getType(MCII, MI) == HexagonII::TypeCR))
+        (llvm_ks::HexagonMCInstrInfo::getType(MCII, MI) == HexagonII::TypeCR))
       FixupKind = *Extended ? Hexagon::fixup_Hexagon_B7_PCREL_X
                             : Hexagon::fixup_Hexagon_B7_PCREL;
     else if (*Extended)
@@ -708,15 +708,15 @@ unsigned HexagonMCCodeEmitter::getExprOpValue(const MCInst &MI,
       default:
         FixupKind = Hexagon::fixup_Hexagon_6_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_Hexagon_PCREL:
+      case llvm_ks::MCSymbolRefExpr::VK_Hexagon_PCREL:
         FixupKind = Hexagon::fixup_Hexagon_6_PCREL_X;
         break;
       // This is part of an extender, GOT_11 is a
       // Word32_U6 unsigned/truncated reloc.
-      case llvm::MCSymbolRefExpr::VK_GOT:
+      case llvm_ks::MCSymbolRefExpr::VK_GOT:
         FixupKind = Hexagon::fixup_Hexagon_GOT_11_X;
         break;
-      case llvm::MCSymbolRefExpr::VK_GOTOFF:
+      case llvm_ks::MCSymbolRefExpr::VK_GOTOFF:
         FixupKind = Hexagon::fixup_Hexagon_GOTREL_11_X;
         break;
       }
@@ -757,7 +757,7 @@ HexagonMCCodeEmitter::getMachineOpValue(MCInst const &MI, MCOperand const &MO,
   return getExprOpValue(MI, MO, MO.getExpr(), Fixups, STI);
 }
 
-MCCodeEmitter *llvm::createHexagonMCCodeEmitter(MCInstrInfo const &MII,
+MCCodeEmitter *llvm_ks::createHexagonMCCodeEmitter(MCInstrInfo const &MII,
                                                 MCRegisterInfo const &MRI,
                                                 MCContext &MCT) {
   return new HexagonMCCodeEmitter(MII, MCT);

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCodeEmitter.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCodeEmitter.h
@@ -23,7 +23,7 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class HexagonMCCodeEmitter : public MCCodeEmitter {
   MCContext &MCT;
@@ -70,6 +70,6 @@ public:
                              MCSubtargetInfo const &STI) const;
 }; // class HexagonMCCodeEmitter
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif /* HEXAGONMCCODEEMITTER_H */

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCompound.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCCompound.cpp
@@ -24,7 +24,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace Hexagon;
 
 #define DEBUG_TYPE "hexagon-mccompound"
@@ -369,7 +369,7 @@ bool lookForCompound(MCInstrInfo const &MCII, MCContext &Context, MCInst &MCI) {
       JExtended = true;
       continue;
     }
-    if (llvm::HexagonMCInstrInfo::getType(MCII, *JumpInst) ==
+    if (llvm_ks::HexagonMCInstrInfo::getType(MCII, *JumpInst) ==
         HexagonII::TypeJ) {
       // Try to pair with another insn (B)undled with jump.
       bool BExtended = false;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCDuplexInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCDuplexInfo.cpp
@@ -20,7 +20,7 @@
 
 #include <map>
 
-using namespace llvm;
+using namespace llvm_ks;
 using namespace Hexagon;
 
 #define DEBUG_TYPE "hexagon-mcduplex-info"

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCELFStreamer.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCELFStreamer.h
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCELFStreamer.h"
 #include "HexagonTargetStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class HexagonMCELFStreamer : public MCELFStreamer {
   std::unique_ptr<MCInstrInfo> MCII;
@@ -40,6 +40,6 @@ public:
 MCStreamer *createHexagonELFStreamer(MCContext &Context, MCAsmBackend &MAB,
                                      raw_pwrite_stream &OS, MCCodeEmitter *CE);
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCExpr.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCExpr.cpp
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCValue.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "hexagon-mcexpr"
 
@@ -29,7 +29,7 @@ bool HexagonNoExtendOperand::evaluateAsRelocatableImpl(
 
 void HexagonNoExtendOperand::visitUsedExpr(MCStreamer &Streamer) const {}
 
-MCFragment *llvm::HexagonNoExtendOperand::findAssociatedFragment() const {
+MCFragment *llvm_ks::HexagonNoExtendOperand::findAssociatedFragment() const {
   return Expr->findAssociatedFragment();
 }
 

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCExpr.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCExpr.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCExpr.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCInst;
 class HexagonNoExtendOperand : public MCTargetExpr {
 public:
@@ -30,6 +30,6 @@ private:
   HexagonNoExtendOperand(MCExpr const *Expr);
   MCExpr const *Expr;
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif // LLVM_LIB_TARGET_HEXAGON_HEXAGONMCEXPR_H

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.cpp
@@ -22,7 +22,7 @@
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
 void HexagonMCInstrInfo::addConstant(MCInst &MI, uint64_t Value,
                                      MCContext &Context) {
   MI.addOperand(MCOperand::createExpr(MCConstantExpr::create(Value, Context)));

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCInstrInfo.h
@@ -17,7 +17,7 @@
 #include "HexagonMCExpr.h"
 #include "llvm/MC/MCInst.h"
 
-namespace llvm {
+namespace llvm_ks {
 class HexagonMCChecker;
 class MCContext;
 class MCInstrDesc;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCShuffler.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCShuffler.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static bool DisableShuffle = false;
 
@@ -96,7 +96,7 @@ bool HexagonMCShuffler::reshuffleTo(MCInst &MCB) {
   return (!getError());
 }
 
-bool llvm::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
+bool llvm_ks::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
                             MCInst &MCB) {
   HexagonMCShuffler MCS(MCII, STI, MCB);
 
@@ -146,7 +146,7 @@ bool llvm::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
 }
 
 unsigned
-llvm::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
+llvm_ks::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
                        MCContext &Context, MCInst &MCB,
                        SmallVector<DuplexCandidate, 8> possibleDuplexes) {
 
@@ -200,7 +200,7 @@ llvm::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
   return HexagonShuffler::SHUFFLE_SUCCESS;
 }
 
-bool llvm::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
+bool llvm_ks::HexagonMCShuffle(MCInstrInfo const &MCII, MCSubtargetInfo const &STI,
                             MCInst &MCB, MCInst const *AddMI, int fixupCount) {
   if (!HexagonMCInstrInfo::isBundle(MCB) || !AddMI)
     return false;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCShuffler.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCShuffler.h
@@ -17,7 +17,7 @@
 
 #include "MCTargetDesc/HexagonShuffler.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCInst;
 

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.cpp
@@ -28,7 +28,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "HexagonGenInstrInfo.inc"
@@ -39,9 +39,9 @@ using namespace llvm;
 #define GET_REGINFO_MC_DESC
 #include "HexagonGenRegisterInfo.inc"
 
-bool llvm::HexagonDisableCompound;
+bool llvm_ks::HexagonDisableCompound;
 
-bool llvm::HexagonDisableDuplex;
+bool llvm_ks::HexagonDisableDuplex;
 
 StringRef HEXAGON_MC::selectHexagonCPU(const Triple &TT, StringRef CPU) {
   if (CPU.empty())
@@ -49,7 +49,7 @@ StringRef HEXAGON_MC::selectHexagonCPU(const Triple &TT, StringRef CPU) {
   return CPU;
 }
 
-MCInstrInfo *llvm::createHexagonMCInstrInfo() {
+MCInstrInfo *llvm_ks::createHexagonMCInstrInfo() {
   MCInstrInfo *X = new MCInstrInfo();
   InitHexagonMCInstrInfo(X);
   return X;
@@ -77,7 +77,7 @@ public:
       : HexagonTargetStreamer(S) {
     auto Bits = STI.getFeatureBits();
     unsigned Flags;
-    if (Bits.to_ullong() & llvm::Hexagon::ArchV5)
+    if (Bits.to_ullong() & llvm_ks::Hexagon::ArchV5)
       Flags = ELF::EF_HEXAGON_MACH_V5;
     else
       Flags = ELF::EF_HEXAGON_MACH_V4;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonMCTargetDesc.h
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-namespace llvm {
+namespace llvm_ks {
 struct InstrItinerary;
 struct InstrStage;
 class MCAsmBackend;

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonShuffler.cpp
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonShuffler.cpp
@@ -25,7 +25,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 // Insn shuffling priority.

--- a/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonShuffler.h
+++ b/llvm/lib/Target/Hexagon/MCTargetDesc/HexagonShuffler.h
@@ -22,9 +22,9 @@
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
-namespace llvm {
+namespace llvm_ks {
 // Insn resources.
 class HexagonResource {
   // Mask of the slots or units that may execute the insn and
@@ -56,7 +56,7 @@ public:
 class HexagonCVIResource : public HexagonResource {
 public:
   typedef std::pair<unsigned, unsigned> UnitsAndLanes;
-  typedef llvm::DenseMap<unsigned, UnitsAndLanes> TypeUnitsAndLanes;
+  typedef llvm_ks::DenseMap<unsigned, UnitsAndLanes> TypeUnitsAndLanes;
 
 private:
   // Available HVX slots.

--- a/llvm/lib/Target/Hexagon/TargetInfo/HexagonTargetInfo.cpp
+++ b/llvm/lib/Target/Hexagon/TargetInfo/HexagonTargetInfo.cpp
@@ -9,9 +9,9 @@
 
 #include "Hexagon.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheHexagonTarget;
+Target llvm_ks::TheHexagonTarget;
 
 extern "C" void LLVMInitializeHexagonTargetInfo() {
   RegisterTarget<Triple::hexagon>  X(TheHexagonTarget, "hexagon", "Hexagon");

--- a/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
+++ b/llvm/lib/Target/Mips/AsmParser/MipsAsmParser.cpp
@@ -35,11 +35,11 @@
 
 #include "keystone/mips.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mips-asm-parser"
 
-namespace llvm {
+namespace llvm_ks {
 class MCInstrInfo;
 }
 
@@ -415,11 +415,11 @@ public:
 
     // Remember the initial assembler options. The user can not modify these.
     AssemblerOptions.push_back(
-        llvm::make_unique<MipsAssemblerOptions>(getSTI().getFeatureBits()));
+        llvm_ks::make_unique<MipsAssemblerOptions>(getSTI().getFeatureBits()));
 
     // Create an assembler options environment for the user to modify.
     AssemblerOptions.push_back(
-        llvm::make_unique<MipsAssemblerOptions>(getSTI().getFeatureBits()));
+        llvm_ks::make_unique<MipsAssemblerOptions>(getSTI().getFeatureBits()));
 
     //getTargetStreamer().updateABIInfo(*this);
 
@@ -1395,7 +1395,7 @@ public:
 }; // class MipsOperand
 } // namespace
 
-namespace llvm {
+namespace llvm_ks {
 extern const MCInstrDesc MipsInsts[];
 }
 static const MCInstrDesc &getInstDesc(unsigned Opcode) {

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsABIFlagsSection.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsABIFlagsSection.h
@@ -14,7 +14,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MipsABIFlags.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCStreamer;
 

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsABIInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsABIInfo.cpp
@@ -13,7 +13,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCTargetOptions.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 static const MCPhysReg O32IntRegs[4] = {Mips::A0, Mips::A1, Mips::A2, Mips::A3};

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsABIInfo.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsABIInfo.h
@@ -14,7 +14,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCTargetOptions;
 class StringRef;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.cpp
@@ -27,7 +27,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // Prepare value for the target space for it
 static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
@@ -434,27 +434,27 @@ void MipsAsmBackend::processFixupValue(const MCAssembler &Asm,
 }
 
 // MCAsmBackend
-MCAsmBackend *llvm::createMipsAsmBackendEL32(const Target &T,
+MCAsmBackend *llvm_ks::createMipsAsmBackendEL32(const Target &T,
                                              const MCRegisterInfo &MRI,
                                              const Triple &TT, StringRef CPU) {
   return new MipsAsmBackend(T, TT.getOS(), /*IsLittle*/ true,
                             /*Is64Bit*/ false);
 }
 
-MCAsmBackend *llvm::createMipsAsmBackendEB32(const Target &T,
+MCAsmBackend *llvm_ks::createMipsAsmBackendEB32(const Target &T,
                                              const MCRegisterInfo &MRI,
                                              const Triple &TT, StringRef CPU) {
   return new MipsAsmBackend(T, TT.getOS(), /*IsLittle*/ false,
                             /*Is64Bit*/ false);
 }
 
-MCAsmBackend *llvm::createMipsAsmBackendEL64(const Target &T,
+MCAsmBackend *llvm_ks::createMipsAsmBackendEL64(const Target &T,
                                              const MCRegisterInfo &MRI,
                                              const Triple &TT, StringRef CPU) {
   return new MipsAsmBackend(T, TT.getOS(), /*IsLittle*/ true, /*Is64Bit*/ true);
 }
 
-MCAsmBackend *llvm::createMipsAsmBackendEB64(const Target &T,
+MCAsmBackend *llvm_ks::createMipsAsmBackendEB64(const Target &T,
                                              const MCRegisterInfo &MRI,
                                              const Triple &TT, StringRef CPU) {
   return new MipsAsmBackend(T, TT.getOS(), /*IsLittle*/ false,

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsAsmBackend.h
@@ -19,7 +19,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/MC/MCAsmBackend.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCAssembler;
 struct MCFixupKindInfo;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsBaseInfo.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsBaseInfo.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// MipsII - This namespace holds all of the target specific flags that
 /// instruction info tracks.

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsELFObjectWriter.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include <list>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 // A helper structure based on ELFRelocationEntry, used for sorting entries in
@@ -423,7 +423,7 @@ bool MipsELFObjectWriter::needsRelocateWithSymbol(const MCSymbol &Sym,
   }
 }
 
-MCObjectWriter *llvm::createMipsELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createMipsELFObjectWriter(raw_pwrite_stream &OS,
                                                 uint8_t OSABI,
                                                 bool IsLittleEndian,
                                                 bool Is64Bit) {

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsELFStreamer.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsELFStreamer.h
@@ -20,7 +20,7 @@
 #include "llvm/MC/MCELFStreamer.h"
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;
@@ -72,5 +72,5 @@ public:
 MCELFStreamer *createMipsELFStreamer(MCContext &Context, MCAsmBackend &MAB,
                                      raw_pwrite_stream &OS,
                                      MCCodeEmitter *Emitter, bool RelaxAll);
-} // namespace llvm.
+} // namespace llvm_ks.
 #endif

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsFixupKinds.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsFixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
   // Although most of the current fixup types reflect a unique relocation
   // one can have multiple fixup types for a given relocation and thus need
@@ -205,7 +205,7 @@ namespace Mips {
     NumTargetFixupKinds = LastTargetFixupKind - FirstTargetFixupKind
   };
 } // namespace Mips
-} // namespace llvm
+} // namespace llvm_ks
 
 
 #endif

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.cpp
@@ -14,7 +14,7 @@
 #include "MipsMCAsmInfo.h"
 #include "llvm/ADT/Triple.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 MipsMCAsmInfo::MipsMCAsmInfo(const Triple &TheTriple) {
   if ((TheTriple.getArch() == Triple::mips) ||

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCAsmInfo.h
@@ -16,7 +16,7 @@
 
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class MipsMCAsmInfo : public MCAsmInfoELF {
@@ -24,6 +24,6 @@ public:
   explicit MipsMCAsmInfo(const Triple &TheTriple);
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCCodeEmitter.cpp
@@ -33,7 +33,7 @@
 #include "MipsGenInstrInfo.inc"
 #undef GET_INSTRMAP_INFO
 
-namespace llvm {
+namespace llvm_ks {
 MCCodeEmitter *createMipsMCCodeEmitterEB(const MCInstrInfo &MCII,
                                          const MCRegisterInfo &MRI,
                                          MCContext &Ctx) {
@@ -45,7 +45,7 @@ MCCodeEmitter *createMipsMCCodeEmitterEL(const MCInstrInfo &MCII,
                                          MCContext &Ctx) {
   return new MipsMCCodeEmitter(MCII, Ctx, true);
 }
-} // End of namespace llvm.
+} // End of namespace llvm_ks.
 
 // If the D<shift> instruction has a shift amount that is greater
 // than 31 (checked in calling routine), lower it to a D<shift>32 instruction

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCCodeEmitter.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCCodeEmitter.h
@@ -18,9 +18,9 @@
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/Support/DataTypes.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
-namespace llvm {
+namespace llvm_ks {
 class MCContext;
 class MCExpr;
 class MCInst;
@@ -240,6 +240,6 @@ public:
                                     SmallVectorImpl<MCFixup> &Fixups,
                                     const MCSubtargetInfo &STI) const;
 }; // class MipsMCCodeEmitter
-} // namespace llvm.
+} // namespace llvm_ks.
 
 #endif

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCExpr.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCExpr.cpp
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mipsmcexpr"
 

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCExpr.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCExpr.h
@@ -14,7 +14,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCValue.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MipsMCExpr : public MCTargetExpr {
 public:
@@ -62,6 +62,6 @@ public:
     return E->getKind() == MCExpr::Target;
   }
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCNaCl.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCNaCl.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCELFStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 // Log2 of the NaCl MIPS sandbox's instruction bundle size.
 static const unsigned MIPS_NACL_BUNDLE_ALIGN = 4u;

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
@@ -28,7 +28,7 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "MipsGenInstrInfo.inc"

--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.h
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.h
@@ -16,7 +16,7 @@
 
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;

--- a/llvm/lib/Target/Mips/MipsAnalyzeImmediate.h
+++ b/llvm/lib/Target/Mips/MipsAnalyzeImmediate.h
@@ -12,7 +12,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
   class MipsAnalyzeImmediate {
   public:

--- a/llvm/lib/Target/Mips/MipsGenInstrInfo.inc
+++ b/llvm/lib/Target/Mips/MipsGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace Mips {
   enum {
@@ -2449,7 +2449,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { Mips::DSPOutFlag20, 0 };
 static const MCPhysReg ImplicitList2[] = { Mips::DSPCarry, 0 };
@@ -5025,7 +5025,7 @@ static inline void InitMipsMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct MipsGenInstrInfo : public TargetInstrInfo {
   explicit MipsGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~MipsGenInstrInfo() override {}
@@ -5036,7 +5036,7 @@ struct MipsGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
 namespace OpName { 
 enum {
@@ -5044,23 +5044,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace Mips
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace Mips
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
 namespace OpTypes { 
 enum OperandType {
@@ -5176,11 +5176,11 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace Mips
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM
 #ifdef GET_INSTRMAP_INFO
 #undef GET_INSTRMAP_INFO
-namespace llvm {
+namespace llvm_ks {
 
 namespace Mips {
 

--- a/llvm/lib/Target/Mips/MipsGenRegisterInfo.inc
+++ b/llvm/lib/Target/Mips/MipsGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass MipsMCRegisterClasses[];
@@ -539,7 +539,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg MipsRegDiffLists[] = {
   /* 0 */ 0, 0,

--- a/llvm/lib/Target/Mips/MipsGenSubtargetInfo.inc
+++ b/llvm/lib/Target/Mips/MipsGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Mips {
 enum : uint64_t {
   FeatureCnMips = 0,
@@ -59,9 +59,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV MipsFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV MipsFeatureKV[] = {
   { "cnmips", "Octeon cnMIPS Support", { Mips::FeatureCnMips }, { Mips::FeatureMips64r2 } },
   { "dsp", "Mips DSP ASE", { Mips::FeatureDSP }, { } },
   { "dspr2", "Mips DSP-R2 ASE", { Mips::FeatureDSPR2 }, { Mips::FeatureDSP } },
@@ -104,7 +104,7 @@ extern const llvm::SubtargetFeatureKV MipsFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV MipsSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV MipsSubTypeKV[] = {
   { "mips1", "Select the mips1 processor", { Mips::FeatureMips1 }, { } },
   { "mips2", "Select the mips2 processor", { Mips::FeatureMips2 }, { } },
   { "mips3", "Select the mips3 processor", { Mips::FeatureMips3 }, { } },
@@ -148,7 +148,7 @@ static inline MCSubtargetInfo *createMipsMCSubtargetInfoImpl(const Triple &TT, S
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::MipsSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::MipsSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/Mips/MipsOptionRecord.h
+++ b/llvm/lib/Target/Mips/MipsOptionRecord.h
@@ -24,7 +24,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MipsELFStreamer;
 class MCSubtargetInfo;
 
@@ -74,5 +74,5 @@ private:
   uint32_t ri_cprmask[4];
   int64_t ri_gp_value;
 };
-} // namespace llvm
+} // namespace llvm_ks
 #endif

--- a/llvm/lib/Target/Mips/MipsTargetStreamer.h
+++ b/llvm/lib/Target/Mips/MipsTargetStreamer.h
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 struct MipsABIFlagsSection;
 
@@ -113,7 +113,7 @@ public:
   }
 
 protected:
-  llvm::Optional<MipsABIInfo> ABI;
+  llvm_ks::Optional<MipsABIInfo> ABI;
   MipsABIFlagsSection ABIFlagsSection;
 
   bool GPRInfoSet;

--- a/llvm/lib/Target/Mips/TargetInfo/MipsTargetInfo.cpp
+++ b/llvm/lib/Target/Mips/TargetInfo/MipsTargetInfo.cpp
@@ -9,10 +9,10 @@
 
 #include "MCTargetDesc/MipsMCTargetDesc.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheMipsTarget, llvm::TheMipselTarget;
-Target llvm::TheMips64Target, llvm::TheMips64elTarget;
+Target llvm_ks::TheMipsTarget, llvm_ks::TheMipselTarget;
+Target llvm_ks::TheMips64Target, llvm_ks::TheMips64elTarget;
 
 extern "C" void LLVMInitializeMipsTargetInfo() {
   RegisterTarget<Triple::mips> X(TheMipsTarget, "mips", "Mips");

--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -33,7 +33,7 @@
 
 #include "keystone/ppc.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static const MCPhysReg RRegs[32] = {
   PPC::R0,  PPC::R1,  PPC::R2,  PPC::R3,

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCAsmBackend.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCAsmBackend.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MachO.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 static uint64_t adjustFixupValue(unsigned Kind, uint64_t Value) {
   switch (Kind) {
@@ -213,7 +213,7 @@ namespace {
 
 } // end anonymous namespace
 
-MCAsmBackend *llvm::createPPCAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createPPCAsmBackend(const Target &T,
                                         const MCRegisterInfo &MRI,
                                         const Triple &TT, StringRef CPU) {
   uint8_t OSABI = MCELFObjectTargetWriter::getOSABI(TT.getOS());

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCELFObjectWriter.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCELFObjectWriter.cpp
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCValue.h"
 #include "llvm/Support/ErrorHandling.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
   class PPCELFObjectWriter : public MCELFObjectTargetWriter {
@@ -416,7 +416,7 @@ bool PPCELFObjectWriter::needsRelocateWithSymbol(const MCSymbol &Sym,
   }
 }
 
-MCObjectWriter *llvm::createPPCELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createPPCELFObjectWriter(raw_pwrite_stream &OS,
                                                bool Is64Bit,
                                                bool IsLittleEndian,
                                                uint8_t OSABI) {

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCFixupKinds.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCFixupKinds.h
@@ -14,7 +14,7 @@
 
 #undef PPC
 
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
 enum Fixups {
   // fixup_ppc_br24 - 24-bit PC relative relocation for direct branches like 'b'

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.cpp
@@ -14,7 +14,7 @@
 #include "PPCMCAsmInfo.h"
 #include "llvm/ADT/Triple.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 PPCMCAsmInfoDarwin::PPCMCAsmInfoDarwin(bool is64Bit, const Triple& T) {
   if (is64Bit) {

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCAsmInfo.h
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class PPCMCAsmInfoDarwin : public MCAsmInfoDarwin {
@@ -30,6 +30,6 @@ public:
   explicit PPCELFMCAsmInfo(bool is64Bit, const Triple &);
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.cpp
@@ -25,7 +25,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -139,7 +139,7 @@ public:
   
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createPPCMCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createPPCMCCodeEmitter(const MCInstrInfo &MCII,
                                             const MCRegisterInfo &MRI,
                                             MCContext &Ctx) {
   return new PPCMCCodeEmitter(MCII, Ctx);

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCExpr.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCExpr.cpp
@@ -14,7 +14,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "ppcmcexpr"
 

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCExpr.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCExpr.h
@@ -14,7 +14,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCValue.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class PPCMCExpr : public MCTargetExpr {
 public:
@@ -95,6 +95,6 @@ public:
     return E->getKind() == MCExpr::Target;
   }
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.cpp
@@ -29,7 +29,7 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "PPCGenInstrInfo.inc"

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.h
@@ -20,7 +20,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/MathExtras.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCPredicates.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCPredicates.cpp
@@ -14,7 +14,7 @@
 #include "PPCPredicates.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
-using namespace llvm;
+using namespace llvm_ks;
 
 PPC::Predicate PPC::InvertPredicate(PPC::Predicate Opcode) {
   switch (Opcode) {

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCPredicates.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCPredicates.h
@@ -21,7 +21,7 @@
 // undefine PPC here. PPC may be predefined on some hosts.
 #undef PPC
 
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
   /// Predicate - These are "(BI << 5) | BO"  for various predicates.
   enum Predicate {

--- a/llvm/lib/Target/PowerPC/PPC.h
+++ b/llvm/lib/Target/PowerPC/PPC.h
@@ -20,7 +20,7 @@
 // GCC #defines PPC on Linux but we use it as our namespace name
 #undef PPC
 
-namespace llvm {
+namespace llvm_ks {
   namespace PPCII {
     
   /// Target Operand Flag enum.
@@ -69,6 +69,6 @@ namespace llvm {
   };
   } // end namespace PPCII
   
-} // end namespace llvm;
+} // end namespace llvm_ks;
 
 #endif

--- a/llvm/lib/Target/PowerPC/PPCGenInstrInfo.inc
+++ b/llvm/lib/Target/PowerPC/PPCGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace PPC {
   enum {
@@ -1751,7 +1751,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { PPC::CR0, 0 };
 static const MCPhysReg ImplicitList2[] = { PPC::CARRY, 0 };
@@ -3642,7 +3642,7 @@ static inline void InitPPCMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct PPCGenInstrInfo : public TargetInstrInfo {
   explicit PPCGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~PPCGenInstrInfo() override {}
@@ -3653,7 +3653,7 @@ struct PPCGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
 namespace OpName { 
 enum {
@@ -3661,23 +3661,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace PPC
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace PPC
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
 namespace OpTypes { 
 enum OperandType {
@@ -3740,11 +3740,11 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace PPC
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM
 #ifdef GET_INSTRMAP_INFO
 #undef GET_INSTRMAP_INFO
-namespace llvm {
+namespace llvm_ks {
 
 namespace PPC {
 

--- a/llvm/lib/Target/PowerPC/PPCGenRegisterInfo.inc
+++ b/llvm/lib/Target/PowerPC/PPCGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass PPCMCRegisterClasses[];
@@ -390,7 +390,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg PPCRegDiffLists[] = {
   /* 0 */ 0, 0,

--- a/llvm/lib/Target/PowerPC/PPCGenSubtargetInfo.inc
+++ b/llvm/lib/Target/PowerPC/PPCGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace PPC {
 enum : uint64_t {
   DeprecatedDST = 0,
@@ -85,9 +85,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV PPCFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV PPCFeatureKV[] = {
   { "64bit", "Enable 64-bit instructions", { PPC::Feature64Bit }, { } },
   { "64bitregs", "Enable 64-bit registers usage for ppc32 [beta]", { PPC::Feature64BitRegs }, { } },
   { "altivec", "Enable Altivec instructions", { PPC::FeatureAltivec }, { } },
@@ -132,7 +132,7 @@ extern const llvm::SubtargetFeatureKV PPCFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV PPCSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV PPCSubTypeKV[] = {
   { "440", "Select the 440 processor", { PPC::Directive440, PPC::FeatureISEL, PPC::FeatureFRES, PPC::FeatureFRSQRTE, PPC::FeatureICBT, PPC::FeatureBookE, PPC::FeatureMSYNC, PPC::FeatureMFTB }, { } },
   { "450", "Select the 450 processor", { PPC::Directive440, PPC::FeatureISEL, PPC::FeatureFRES, PPC::FeatureFRSQRTE, PPC::FeatureICBT, PPC::FeatureBookE, PPC::FeatureMSYNC, PPC::FeatureMFTB }, { } },
   { "601", "Select the 601 processor", { PPC::Directive601 }, { } },
@@ -193,7 +193,7 @@ static inline MCSubtargetInfo *createPPCMCSubtargetInfoImpl(const Triple &TT, St
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::PPCSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::PPCSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/PowerPC/PPCTargetStreamer.h
+++ b/llvm/lib/Target/PowerPC/PPCTargetStreamer.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 class PPCTargetStreamer : public MCTargetStreamer {
 public:
   PPCTargetStreamer(MCStreamer &S);

--- a/llvm/lib/Target/PowerPC/TargetInfo/PowerPCTargetInfo.cpp
+++ b/llvm/lib/Target/PowerPC/TargetInfo/PowerPCTargetInfo.cpp
@@ -9,9 +9,9 @@
 
 #include "PPC.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::ThePPC32Target, llvm::ThePPC64Target, llvm::ThePPC64LETarget;
+Target llvm_ks::ThePPC32Target, llvm_ks::ThePPC64Target, llvm_ks::ThePPC64LETarget;
 
 extern "C" void LLVMInitializePowerPCTargetInfo() {
   RegisterTarget<Triple::ppc>

--- a/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
+++ b/llvm/lib/Target/Sparc/AsmParser/SparcAsmParser.cpp
@@ -23,11 +23,11 @@
 
 #include "keystone/sparc.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // The generated AsmMatcher SparcGenAsmMatcher uses "Sparc" as the target
 // namespace. But SPARC backend uses "SP" as its namespace.
-namespace llvm {
+namespace llvm_ks {
   namespace Sparc {
     using namespace SP;
   }

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcAsmBackend.cpp
@@ -17,7 +17,7 @@
 #include "llvm/MC/MCValue.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static unsigned adjustFixupValue(unsigned Kind, uint64_t Value) {
   switch (Kind) {
@@ -297,7 +297,7 @@ namespace {
 
 } // end anonymous namespace
 
-MCAsmBackend *llvm::createSparcAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createSparcAsmBackend(const Target &T,
                                           const MCRegisterInfo &MRI,
                                           const Triple &TT, StringRef CPU) {
   return new ELFSparcAsmBackend(T, TT.getOS());

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcELFObjectWriter.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcELFObjectWriter.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCValue.h"
 #include "llvm/Support/ErrorHandling.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
   class SparcELFObjectWriter : public MCELFObjectTargetWriter {
@@ -131,7 +131,7 @@ bool SparcELFObjectWriter::needsRelocateWithSymbol(const MCSymbol &Sym,
   }
 }
 
-MCObjectWriter *llvm::createSparcELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createSparcELFObjectWriter(raw_pwrite_stream &OS,
                                                  bool Is64Bit,
                                                  bool IsLittleEndian,
                                                  uint8_t OSABI) {

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcFixupKinds.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcFixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
   namespace Sparc {
     enum Fixups {
       // fixup_sparc_call30 - 30-bit PC relative relocation for call

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.cpp
@@ -16,7 +16,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/MC/MCStreamer.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 SparcELFMCAsmInfo::SparcELFMCAsmInfo(const Triple &TheTriple) {
   bool isV9 = (TheTriple.getArch() == Triple::sparcv9);

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCAsmInfo.h
@@ -16,7 +16,7 @@
 
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class SparcELFMCAsmInfo : public MCAsmInfoELF {
@@ -31,6 +31,6 @@ public:
 
 };
 
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCCodeEmitter.cpp
@@ -24,7 +24,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/EndianStream.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -73,7 +73,7 @@ public:
 };
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createSparcMCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createSparcMCCodeEmitter(const MCInstrInfo &MCII,
                                               const MCRegisterInfo &MRI,
                                               MCContext &Ctx) {
   return new SparcMCCodeEmitter(Ctx);

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Object/ELF.h"
 
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "sparcmcexpr"
 

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCExpr.h
@@ -18,7 +18,7 @@
 #include "SparcFixupKinds.h"
 #include "llvm/MC/MCExpr.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class StringRef;
 class SparcMCExpr : public MCTargetExpr {
@@ -107,6 +107,6 @@ public:
   static Sparc::Fixups getFixupKind(VariantKind Kind);
 };
 
-} // end namespace llvm.
+} // end namespace llvm_ks.
 
 #endif

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.cpp
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "SparcGenInstrInfo.inc"

--- a/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.h
+++ b/llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.h
@@ -16,7 +16,7 @@
 
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;

--- a/llvm/lib/Target/Sparc/SparcGenInstrInfo.inc
+++ b/llvm/lib/Target/Sparc/SparcGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace SP {
   enum {
@@ -583,7 +583,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { SP::ICC, 0 };
 static const MCPhysReg ImplicitList2[] = { SP::O6, 0 };
@@ -1271,7 +1271,7 @@ static inline void InitSparcMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct SparcGenInstrInfo : public TargetInstrInfo {
   explicit SparcGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~SparcGenInstrInfo() override {}
@@ -1282,7 +1282,7 @@ struct SparcGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace SP {
 namespace OpName { 
 enum {
@@ -1290,23 +1290,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace SP
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace SP {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace SP
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace SP {
 namespace OpTypes { 
 enum OperandType {
@@ -1331,5 +1331,5 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace SP
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM

--- a/llvm/lib/Target/Sparc/SparcGenRegisterInfo.inc
+++ b/llvm/lib/Target/Sparc/SparcGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass SPMCRegisterClasses[];
@@ -250,7 +250,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg SparcRegDiffLists[] = {
   /* 0 */ 64976, 1, 1, 1, 0,

--- a/llvm/lib/Target/Sparc/SparcGenSubtargetInfo.inc
+++ b/llvm/lib/Target/Sparc/SparcGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace Sparc {
 enum : uint64_t {
   FeatureHardQuad = 0,
@@ -27,9 +27,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV SparcFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV SparcFeatureKV[] = {
   { "deprecated-v8", "Enable deprecated V8 instructions in V9 mode", { Sparc::FeatureV8Deprecated }, { } },
   { "hard-quad-float", "Enable quad-word floating point instructions", { Sparc::FeatureHardQuad }, { } },
   { "popc", "Use the popc (population count) instruction", { Sparc::UsePopc }, { } },
@@ -40,7 +40,7 @@ extern const llvm::SubtargetFeatureKV SparcFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV SparcSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV SparcSubTypeKV[] = {
   { "f934", "Select the f934 processor", { }, { } },
   { "generic", "Select the generic processor", { }, { } },
   { "hypersparc", "Select the hypersparc processor", { }, { } },
@@ -87,7 +87,7 @@ static inline MCSubtargetInfo *createSparcMCSubtargetInfoImpl(const Triple &TT, 
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::SparcSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::SparcSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/Sparc/SparcTargetStreamer.h
+++ b/llvm/lib/Target/Sparc/SparcTargetStreamer.h
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCELFStreamer.h"
 #include "llvm/MC/MCStreamer.h"
 
-namespace llvm {
+namespace llvm_ks {
 class SparcTargetStreamer : public MCTargetStreamer {
 public:
   SparcTargetStreamer(MCStreamer &S);
@@ -42,6 +42,6 @@ public:
   void emitSparcRegisterIgnore(unsigned reg) override {}
   void emitSparcRegisterScratch(unsigned reg) override {}
 };
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/Sparc/TargetInfo/SparcTargetInfo.cpp
+++ b/llvm/lib/Target/Sparc/TargetInfo/SparcTargetInfo.cpp
@@ -9,11 +9,11 @@
 
 #include "MCTargetDesc/SparcMCTargetDesc.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheSparcTarget;
-Target llvm::TheSparcV9Target;
-Target llvm::TheSparcelTarget;
+Target llvm_ks::TheSparcTarget;
+Target llvm_ks::TheSparcV9Target;
+Target llvm_ks::TheSparcelTarget;
 
 extern "C" void LLVMInitializeSparcTargetInfo() {
   RegisterTarget<Triple::sparc> X(TheSparcTarget, "sparc",

--- a/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
+++ b/llvm/lib/Target/SystemZ/AsmParser/SystemZAsmParser.cpp
@@ -20,7 +20,7 @@
 
 #include "keystone/systemz.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // Return true if Expr is in the range [MinValue, MaxValue].
 static bool inRange(const MCExpr *Expr, int64_t MinValue, int64_t MaxValue) {

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmBackend.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmBackend.cpp
@@ -17,7 +17,7 @@
 
 #include <keystone/keystone.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 // Value is a fully-resolved relocation value: Symbol + Addend [- Pivot].
 // Return the bits that should be installed in a relocation field for
@@ -115,7 +115,7 @@ bool SystemZMCAsmBackend::writeNopData(uint64_t Count,
   return true;
 }
 
-MCAsmBackend *llvm::createSystemZMCAsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createSystemZMCAsmBackend(const Target &T,
                                               const MCRegisterInfo &MRI,
                                               const Triple &TT, StringRef CPU) {
   uint8_t OSABI = MCELFObjectTargetWriter::getOSABI(TT.getOS());

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.cpp
@@ -11,7 +11,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCSectionELF.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 SystemZMCAsmInfo::SystemZMCAsmInfo(const Triple &TT) {
   PointerSize = 8;

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCAsmInfo.h
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCAsmInfoELF.h"
 #include "llvm/Support/Compiler.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class SystemZMCAsmInfo : public MCAsmInfoELF {
@@ -21,6 +21,6 @@ public:
   explicit SystemZMCAsmInfo(const Triple &TT);
 };
 
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCCodeEmitter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCCodeEmitter.cpp
@@ -20,7 +20,7 @@
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -114,7 +114,7 @@ private:
 };
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createSystemZMCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createSystemZMCCodeEmitter(const MCInstrInfo &MCII,
                                                 const MCRegisterInfo &MRI,
                                                 MCContext &Ctx) {
   return new SystemZMCCodeEmitter(MCII, Ctx);

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCFixups.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCFixups.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace SystemZ {
 enum FixupKind {
   // These correspond directly to R_390_* relocations.
@@ -25,6 +25,6 @@ enum FixupKind {
   NumTargetFixupKinds = LastTargetFixupKind - FirstTargetFixupKind
 };
 } // end namespace SystemZ
-} // end namespace llvm
+} // end namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCObjectWriter.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCObjectWriter.cpp
@@ -13,7 +13,7 @@
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCValue.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 class SystemZObjectWriter : public MCELFObjectTargetWriter {
@@ -153,7 +153,7 @@ unsigned SystemZObjectWriter::getRelocType(MCContext &Ctx,
   }
 }
 
-MCObjectWriter *llvm::createSystemZObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createSystemZObjectWriter(raw_pwrite_stream &OS,
                                                 uint8_t OSABI) {
   MCELFObjectTargetWriter *MOTW = new SystemZObjectWriter(OSABI);
   return createELFObjectWriter(MOTW, OS, /*IsLittleEndian=*/false);

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.cpp
@@ -16,7 +16,7 @@
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_INSTRINFO_MC_DESC
 #include "SystemZGenInstrInfo.inc"

--- a/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.h
+++ b/llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.h
@@ -12,7 +12,7 @@
 
 #include "llvm/Support/DataTypes.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCAsmBackend;
 class MCCodeEmitter;
@@ -88,7 +88,7 @@ MCAsmBackend *createSystemZMCAsmBackend(const Target &T,
                                         const Triple &TT, StringRef CPU);
 
 MCObjectWriter *createSystemZObjectWriter(raw_pwrite_stream &OS, uint8_t OSABI);
-} // end namespace llvm
+} // end namespace llvm_ks
 
 // Defines symbolic names for SystemZ registers.
 // This defines a mapping from register name to register number.

--- a/llvm/lib/Target/SystemZ/SystemZGenInstrInfo.inc
+++ b/llvm/lib/Target/SystemZ/SystemZGenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace SystemZ {
   enum {
@@ -1392,7 +1392,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { SystemZ::CC, 0 };
 static const MCPhysReg ImplicitList2[] = { SystemZ::R0L, 0 };
@@ -2974,7 +2974,7 @@ static inline void InitSystemZMCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct SystemZGenInstrInfo : public TargetInstrInfo {
   explicit SystemZGenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~SystemZGenInstrInfo() override {}
@@ -2985,7 +2985,7 @@ struct SystemZGenInstrInfo : public TargetInstrInfo {
 
 #ifdef GET_INSTRINFO_OPERAND_ENUM
 #undef GET_INSTRINFO_OPERAND_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace SystemZ {
 namespace OpName { 
 enum {
@@ -2993,23 +2993,23 @@ OPERAND_LAST
 };
 } // end namespace OpName
 } // end namespace SystemZ
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_OPERAND_ENUM
 #ifdef GET_INSTRINFO_NAMED_OPS
 #undef GET_INSTRINFO_NAMED_OPS
-namespace llvm {
+namespace llvm_ks {
 namespace SystemZ {
 LLVM_READONLY
 int16_t getNamedOperandIdx(uint16_t Opcode, uint16_t NamedIdx) {
   return -1;
 }
 } // end namespace SystemZ
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif //GET_INSTRINFO_NAMED_OPS
 
 #ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM
 #undef GET_INSTRINFO_OPERAND_TYPES_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace SystemZ {
 namespace OpTypes { 
 enum OperandType {
@@ -3093,11 +3093,11 @@ enum OperandType {
 };
 } // end namespace OpTypes
 } // end namespace SystemZ
-} // end namespace llvm
+} // end namespace llvm_ks
 #endif // GET_INSTRINFO_OPERAND_TYPES_ENUM
 #ifdef GET_INSTRMAP_INFO
 #undef GET_INSTRMAP_INFO
-namespace llvm {
+namespace llvm_ks {
 
 namespace SystemZ {
 

--- a/llvm/lib/Target/SystemZ/SystemZGenRegisterInfo.inc
+++ b/llvm/lib/Target/SystemZ/SystemZGenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass SystemZMCRegisterClasses[];
@@ -235,7 +235,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg SystemZRegDiffLists[] = {
   /* 0 */ 64953, 1, 1, 1, 0,

--- a/llvm/lib/Target/SystemZ/SystemZGenSubtargetInfo.inc
+++ b/llvm/lib/Target/SystemZ/SystemZGenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace SystemZ {
 enum : uint64_t {
   FeatureDistinctOps = 0,
@@ -31,9 +31,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV SystemZFeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV SystemZFeatureKV[] = {
   { "distinct-ops", "Assume that the distinct-operands facility is installed", { SystemZ::FeatureDistinctOps }, { } },
   { "fast-serialization", "Assume that the fast-serialization facility is installed", { SystemZ::FeatureFastSerialization }, { } },
   { "fp-extension", "Assume that the floating-point extension facility is installed", { SystemZ::FeatureFPExtension }, { } },
@@ -48,7 +48,7 @@ extern const llvm::SubtargetFeatureKV SystemZFeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV SystemZSubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV SystemZSubTypeKV[] = {
   { "generic", "Select the generic processor", { }, { } },
   { "z10", "Select the z10 processor", { }, { } },
   { "z13", "Select the z13 processor", { SystemZ::FeatureDistinctOps, SystemZ::FeatureLoadStoreOnCond, SystemZ::FeatureHighWord, SystemZ::FeatureFPExtension, SystemZ::FeaturePopulationCount, SystemZ::FeatureFastSerialization, SystemZ::FeatureInterlockedAccess1, SystemZ::FeatureTransactionalExecution, SystemZ::FeatureProcessorAssist, SystemZ::FeatureVector }, { } },
@@ -82,7 +82,7 @@ static inline MCSubtargetInfo *createSystemZMCSubtargetInfoImpl(const Triple &TT
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::SystemZSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::SystemZSubtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);

--- a/llvm/lib/Target/SystemZ/TargetInfo/SystemZTargetInfo.cpp
+++ b/llvm/lib/Target/SystemZ/TargetInfo/SystemZTargetInfo.cpp
@@ -10,9 +10,9 @@
 #include "MCTargetDesc/SystemZMCTargetDesc.h"
 #include "llvm/Support/TargetRegistry.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheSystemZTarget;
+Target llvm_ks::TheSystemZTarget;
 
 extern "C" void LLVMInitializeSystemZTargetInfo() {
   RegisterTarget<Triple::systemz>

--- a/llvm/lib/Target/X86/AsmParser/X86AsmInstrumentation.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmInstrumentation.cpp
@@ -92,7 +92,7 @@
 //   register as a frame register and temprorary override current CFA
 //   register.
 
-namespace llvm {
+namespace llvm_ks {
 
 X86AsmInstrumentation::X86AsmInstrumentation(const MCSubtargetInfo *&STI)
     : STI(STI), InitialFrameReg(0) {}

--- a/llvm/lib/Target/X86/AsmParser/X86AsmInstrumentation.h
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmInstrumentation.h
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace llvm {
+namespace llvm_ks {
 
 class MCContext;
 class MCInst;

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -40,7 +40,7 @@
 
 #include "keystone/x86.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
 
@@ -779,8 +779,8 @@ private:
   unsigned GetSIDIForRegClass(unsigned RegClassID, unsigned Reg, bool IsSIReg);
   void
   AddDefaultSrcDestOperands(OperandVector &Operands,
-                            std::unique_ptr<llvm::MCParsedAsmOperand> &&Src,
-                            std::unique_ptr<llvm::MCParsedAsmOperand> &&Dst);
+                            std::unique_ptr<llvm_ks::MCParsedAsmOperand> &&Src,
+                            std::unique_ptr<llvm_ks::MCParsedAsmOperand> &&Dst);
   bool VerifyAndAdjustOperands(OperandVector &OrigOperands,
                                OperandVector &FinalOperands);
   std::unique_ptr<X86Operand> ParseOperand(std::string Mnem, unsigned int &KsError);
@@ -1139,8 +1139,8 @@ unsigned X86AsmParser::GetSIDIForRegClass(unsigned RegClassID, unsigned Reg,
 }
 
 void X86AsmParser::AddDefaultSrcDestOperands(
-    OperandVector& Operands, std::unique_ptr<llvm::MCParsedAsmOperand> &&Src,
-    std::unique_ptr<llvm::MCParsedAsmOperand> &&Dst) {
+    OperandVector& Operands, std::unique_ptr<llvm_ks::MCParsedAsmOperand> &&Src,
+    std::unique_ptr<llvm_ks::MCParsedAsmOperand> &&Dst) {
   if (isParsingIntelSyntax()) {
     Operands.push_back(std::move(Dst));
     Operands.push_back(std::move(Src));

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParserCommon.h
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParserCommon.h
@@ -12,7 +12,7 @@
 
 #include "llvm/Support/MathExtras.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 inline bool isImmSExti16i8Value(uint64_t Value) {
   return isInt<8>(Value) ||
@@ -36,6 +36,6 @@ inline bool isImmUnsignedi8Value(uint64_t Value) {
   return isUInt<8>(Value) || isInt<8>(Value);
 }
 
-} // End of namespace llvm
+} // End of namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/X86/AsmParser/X86Operand.h
+++ b/llvm/lib/Target/X86/AsmParser/X86Operand.h
@@ -18,7 +18,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "MCTargetDesc/X86MCTargetDesc.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 /// X86Operand - Instances of this class represent a parsed X86 machine
 /// instruction.
@@ -465,7 +465,7 @@ struct X86Operand : public MCParsedAsmOperand {
 
   static std::unique_ptr<X86Operand> CreateToken(StringRef Str, SMLoc Loc) {
     SMLoc EndLoc = SMLoc::getFromPointer(Loc.getPointer() + Str.size());
-    auto Res = llvm::make_unique<X86Operand>(Token, Loc, EndLoc);
+    auto Res = llvm_ks::make_unique<X86Operand>(Token, Loc, EndLoc);
     Res->Tok.Data = Str.data();
     Res->Tok.Length = Str.size();
     return Res;
@@ -475,7 +475,7 @@ struct X86Operand : public MCParsedAsmOperand {
   CreateReg(unsigned RegNo, SMLoc StartLoc, SMLoc EndLoc,
             bool AddressOf = false, SMLoc OffsetOfLoc = SMLoc(),
             StringRef SymName = StringRef(), void *OpDecl = nullptr) {
-    auto Res = llvm::make_unique<X86Operand>(Register, StartLoc, EndLoc);
+    auto Res = llvm_ks::make_unique<X86Operand>(Register, StartLoc, EndLoc);
     Res->Reg.RegNo = RegNo;
     Res->AddressOf = AddressOf;
     Res->OffsetOfLoc = OffsetOfLoc;
@@ -486,7 +486,7 @@ struct X86Operand : public MCParsedAsmOperand {
 
   static std::unique_ptr<X86Operand> CreateImm(const MCExpr *Val,
                                                SMLoc StartLoc, SMLoc EndLoc) {
-    auto Res = llvm::make_unique<X86Operand>(Immediate, StartLoc, EndLoc);
+    auto Res = llvm_ks::make_unique<X86Operand>(Immediate, StartLoc, EndLoc);
     Res->Imm.Val = Val;
     return Res;
   }
@@ -496,7 +496,7 @@ struct X86Operand : public MCParsedAsmOperand {
   CreateMem(unsigned ModeSize, const MCExpr *Disp, SMLoc StartLoc, SMLoc EndLoc,
             unsigned Size = 0, StringRef SymName = StringRef(),
             void *OpDecl = nullptr) {
-    auto Res = llvm::make_unique<X86Operand>(Memory, StartLoc, EndLoc);
+    auto Res = llvm_ks::make_unique<X86Operand>(Memory, StartLoc, EndLoc);
     Res->Mem.SegReg   = 0;
     Res->Mem.Disp     = Disp;
     Res->Mem.BaseReg  = 0;
@@ -523,7 +523,7 @@ struct X86Operand : public MCParsedAsmOperand {
     // The scale should always be one of {1,2,4,8}.
     assert(((Scale == 1 || Scale == 2 || Scale == 4 || Scale == 8)) &&
            "Invalid scale!");
-    auto Res = llvm::make_unique<X86Operand>(Memory, StartLoc, EndLoc);
+    auto Res = llvm_ks::make_unique<X86Operand>(Memory, StartLoc, EndLoc);
     Res->Mem.SegReg   = SegReg;
     Res->Mem.Disp     = Disp;
     Res->Mem.BaseReg  = BaseReg;
@@ -538,6 +538,6 @@ struct X86Operand : public MCParsedAsmOperand {
   }
 };
 
-} // End of namespace llvm
+} // End of namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -28,7 +28,7 @@
 
 #include <keystone/keystone.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 static unsigned getFixupKindLog2Size(unsigned Kind) {
   switch (Kind) {
@@ -768,7 +768,7 @@ public:
 
 } // end anonymous namespace
 
-MCAsmBackend *llvm::createX86_32AsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createX86_32AsmBackend(const Target &T,
                                            const MCRegisterInfo &MRI,
                                            const Triple &TheTriple,
                                            StringRef CPU) {
@@ -780,7 +780,7 @@ MCAsmBackend *llvm::createX86_32AsmBackend(const Target &T,
   return new ELFX86_32AsmBackend(T, OSABI, CPU);
 }
 
-MCAsmBackend *llvm::createX86_64AsmBackend(const Target &T,
+MCAsmBackend *llvm_ks::createX86_64AsmBackend(const Target &T,
                                            const MCRegisterInfo &MRI,
                                            const Triple &TheTriple,
                                            StringRef CPU) {

--- a/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86BaseInfo.h
@@ -22,7 +22,7 @@
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/ErrorHandling.h"
 
-namespace llvm {
+namespace llvm_ks {
 
 namespace X86 {
   // Enums for memory operand decoding.  Each memory operand is represented with
@@ -774,6 +774,6 @@ namespace X86II {
   }
 }
 
-} // end namespace llvm;
+} // end namespace llvm_ks;
 
 #endif

--- a/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
@@ -16,7 +16,7 @@
 #include "llvm/Support/ELF.h"
 #include "llvm/Support/ErrorHandling.h"
 
-using namespace llvm;
+using namespace llvm_ks;
 
 namespace {
   class X86ELFObjectWriter : public MCELFObjectTargetWriter {
@@ -261,7 +261,7 @@ unsigned X86ELFObjectWriter::getRelocType(MCContext &Ctx, const MCValue &Target,
   return getRelocType32(Modifier, getType32(Type), IsPCRel);
 }
 
-MCObjectWriter *llvm::createX86ELFObjectWriter(raw_pwrite_stream &OS,
+MCObjectWriter *llvm_ks::createX86ELFObjectWriter(raw_pwrite_stream &OS,
                                                bool IsELF64, uint8_t OSABI,
                                                uint16_t EMachine) {
   MCELFObjectTargetWriter *MOTW =

--- a/llvm/lib/Target/X86/MCTargetDesc/X86FixupKinds.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86FixupKinds.h
@@ -12,7 +12,7 @@
 
 #include "llvm/MC/MCFixup.h"
 
-namespace llvm {
+namespace llvm_ks {
 namespace X86 {
 enum Fixups {
   reloc_riprel_4byte = FirstTargetFixupKind, // 32-bit rip-relative

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -18,7 +18,7 @@
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/ELF.h"
-using namespace llvm;
+using namespace llvm_ks;
 
 //#include <iostream>
 enum AsmWriterFlavorTy {

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
@@ -19,7 +19,7 @@
 #include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 
-namespace llvm {
+namespace llvm_ks {
 class Triple;
 
 class X86MCAsmInfoDarwin : public MCAsmInfoDarwin {
@@ -48,6 +48,6 @@ class X86MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
 public:
   explicit X86MCAsmInfoGNUCOFF(const Triple &Triple);
 };
-} // namespace llvm
+} // namespace llvm_ks
 
 #endif

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
@@ -26,7 +26,7 @@
 
 #include <keystone/keystone.h>
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define DEBUG_TYPE "mccodeemitter"
 
@@ -172,7 +172,7 @@ public:
 
 } // end anonymous namespace
 
-MCCodeEmitter *llvm::createX86MCCodeEmitter(const MCInstrInfo &MCII,
+MCCodeEmitter *llvm_ks::createX86MCCodeEmitter(const MCInstrInfo &MCII,
                                             const MCRegisterInfo &MRI,
                                             MCContext &Ctx) {
   return new X86MCCodeEmitter(MCII, Ctx);

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -27,7 +27,7 @@
 #include <intrin.h>
 #endif
 
-using namespace llvm;
+using namespace llvm_ks;
 
 #define GET_REGINFO_MC_DESC
 #include "X86GenRegisterInfo.inc"
@@ -184,7 +184,7 @@ extern "C" void LLVMInitializeX86TargetMC() {
                                        createX86_64AsmBackend);
 }
 
-unsigned llvm::getX86SubSuperRegisterOrZero(unsigned Reg, unsigned Size,
+unsigned llvm_ks::getX86SubSuperRegisterOrZero(unsigned Reg, unsigned Size,
                                             bool High) {
   switch (Size) {
   default: return 0;
@@ -357,7 +357,7 @@ unsigned llvm::getX86SubSuperRegisterOrZero(unsigned Reg, unsigned Size,
   }
 }
 
-unsigned llvm::getX86SubSuperRegister(unsigned Reg, unsigned Size, bool High) {
+unsigned llvm_ks::getX86SubSuperRegister(unsigned Reg, unsigned Size, bool High) {
   unsigned Res = getX86SubSuperRegisterOrZero(Reg, Size, High);
   assert(Res != 0 && "Unexpected register or VT");
   return Res;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
@@ -19,7 +19,7 @@
 #include "llvm/Support/DataTypes.h"
 #include <string>
 
-namespace llvm {
+namespace llvm_ks {
 class MCAsmBackend;
 class MCCodeEmitter;
 class MCContext;

--- a/llvm/lib/Target/X86/TargetInfo/X86TargetInfo.cpp
+++ b/llvm/lib/Target/X86/TargetInfo/X86TargetInfo.cpp
@@ -9,9 +9,9 @@
 
 #include "MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/Support/TargetRegistry.h"
-using namespace llvm;
+using namespace llvm_ks;
 
-Target llvm::TheX86_32Target, llvm::TheX86_64Target;
+Target llvm_ks::TheX86_32Target, llvm_ks::TheX86_64Target;
 
 extern "C" void LLVMInitializeX86TargetInfo() {
   RegisterTarget<Triple::x86>

--- a/llvm/lib/Target/X86/X86GenInstrInfo.inc
+++ b/llvm/lib/Target/X86/X86GenInstrInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_INSTRINFO_ENUM
 #undef GET_INSTRINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 namespace X86 {
   enum {
@@ -15567,7 +15567,7 @@ namespace Sched {
 
 #ifdef GET_INSTRINFO_MC_DESC
 #undef GET_INSTRINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 static const MCPhysReg ImplicitList1[] = { X86::AL, X86::EFLAGS, 0 };
 static const MCPhysReg ImplicitList2[] = { X86::AX, X86::EFLAGS, 0 };
@@ -31194,7 +31194,7 @@ static inline void InitX86MCInstrInfo(MCInstrInfo *II) {
 
 #ifdef GET_INSTRINFO_HEADER
 #undef GET_INSTRINFO_HEADER
-namespace llvm {
+namespace llvm_ks {
 struct X86GenInstrInfo : public TargetInstrInfo {
   explicit X86GenInstrInfo(int CFSetupOpcode = -1, int CFDestroyOpcode = -1, int CatchRetOpcode = -1);
   ~X86GenInstrInfo() override {}

--- a/llvm/lib/Target/X86/X86GenRegisterInfo.inc
+++ b/llvm/lib/Target/X86/X86GenRegisterInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_REGINFO_ENUM
 #undef GET_REGINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 
 class MCRegisterClass;
 extern const MCRegisterClass X86MCRegisterClasses[];
@@ -373,7 +373,7 @@ enum {
 
 #ifdef GET_REGINFO_MC_DESC
 #undef GET_REGINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 
 extern const MCPhysReg X86RegDiffLists[] = {
   /* 0 */ 0, 1, 0,

--- a/llvm/lib/Target/X86/X86GenSubtargetInfo.inc
+++ b/llvm/lib/Target/X86/X86GenSubtargetInfo.inc
@@ -9,7 +9,7 @@
 
 #ifdef GET_SUBTARGETINFO_ENUM
 #undef GET_SUBTARGETINFO_ENUM
-namespace llvm {
+namespace llvm_ks {
 namespace X86 {
 enum : uint64_t {
   Feature3DNow = 0,
@@ -106,9 +106,9 @@ enum : uint64_t {
 
 #ifdef GET_SUBTARGETINFO_MC_DESC
 #undef GET_SUBTARGETINFO_MC_DESC
-namespace llvm {
+namespace llvm_ks {
 // Sorted (by key) array of values for CPU features.
-extern const llvm::SubtargetFeatureKV X86FeatureKV[] = {
+extern const llvm_ks::SubtargetFeatureKV X86FeatureKV[] = {
   { "16bit-mode", "16-bit mode (i8086)", { X86::Mode16Bit }, { } },
   { "32bit-mode", "32-bit mode (80386)", { X86::Mode32Bit }, { } },
   { "3dnow", "Enable 3DNow! instructions", { X86::Feature3DNow }, { X86::FeatureMMX } },
@@ -198,7 +198,7 @@ extern const llvm::SubtargetFeatureKV X86FeatureKV[] = {
 };
 
 // Sorted (by key) array of values for CPU subtype.
-extern const llvm::SubtargetFeatureKV X86SubTypeKV[] = {
+extern const llvm_ks::SubtargetFeatureKV X86SubTypeKV[] = {
   { "amdfam10", "Select the amdfam10 processor", { X86::FeatureSSE4A, X86::Feature3DNowA, X86::FeatureFXSR, X86::FeatureCMPXCHG16B, X86::FeatureLZCNT, X86::FeaturePOPCNT, X86::FeatureSlowBTMem, X86::FeatureSlowSHLD, X86::FeatureLAHFSAHF }, { } },
   { "athlon", "Select the athlon processor", { X86::FeatureSlowUAMem16, X86::Feature3DNowA, X86::FeatureSlowBTMem, X86::FeatureSlowSHLD }, { } },
   { "athlon-4", "Select the athlon-4 processor", { X86::FeatureSlowUAMem16, X86::FeatureSSE1, X86::Feature3DNowA, X86::FeatureFXSR, X86::FeatureSlowBTMem, X86::FeatureSlowSHLD }, { } },
@@ -293,7 +293,7 @@ static inline MCSubtargetInfo *createX86MCSubtargetInfoImpl(const Triple &TT, St
 #include "llvm/Support/raw_ostream.h"
 // ParseSubtargetFeatures - Parses features string setting specified
 // subtarget options.
-void llvm::X86Subtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
+void llvm_ks::X86Subtarget::ParseSubtargetFeatures(StringRef CPU, StringRef FS) {
   DEBUG(dbgs() << "\nFeatures:" << FS);
   DEBUG(dbgs() << "\nCPU:" << CPU << "\n\n");
   InitMCProcessorInfo(CPU, FS);


### PR DESCRIPTION
This prevents symbol collisions when the Keystone library is linked with the LLVM libraries.

Renaming was done by the following repository-wide substitutions:
* `namespace llvm` -> `namespace llvm_ks`
* `llvm::` -> `llvm_ks::`

See:
https://www.freelists.org/post/keystone-engine/Linking-to-project-using-also-LLVM

I have no problem to name the namespace differently or do some more changes on other places if needed.