### PR TITLE
Auto-detect install libdir to enable multi-arch debian builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,13 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
 else()
     set(CMAKE_C_VISIBILITY_PRESET hidden)
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+    # Use GNUInstallDirs to set LLVM_LIBDIR_SUFFIX. This should automatically
+    # handle cases where the libdir should be lib/, lib64/, or lib/<arch>/
+    # depending on the target system and cmake options.
+    include(GNUInstallDirs)
+    string(REGEX REPLACE "lib(.*)$" "\\1" LLVM_LIBDIR_SUFFIX "${CMAKE_INSTALL_LIBDIR}")
+    set(LLVM_LIBDIR_SUFFIX "${LLVM_LIBDIR_SUFFIX}" CACHE STRING "Define suffix of library directory name (32/64)")
 endif()
 
 # Force static runtime libraries

--- a/make-common.sh
+++ b/make-common.sh
@@ -3,10 +3,6 @@ BUILDTYPE='Release'
 # on MacOS, build universal binaries by default
 ARCH='i386;x86_64'
 
-# Linux FHS wants to install x64 libraries in "lib64"
-# Examples are Fedora, Redhat, Suse.
-LLVM_LIBDIR_SUFFIX=''
-
 # by default we do NOT build 32bit on 64bit system
 LLVM_BUILD_32_BITS=0
 
@@ -21,9 +17,6 @@ while [ "$1" != "" ]; do
       ;;
     lib32)
       LLVM_BUILD_32_BITS=1
-      ;;
-    lib64)
-      LLVM_LIBDIR_SUFFIX='64'
       ;;
     debug)
       BUILDTYPE='Debug'

--- a/make-lib.sh
+++ b/make-lib.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build static library of Keystone Engine
-# syntax: make-lib.sh [debug] [macos-no-universal] [lib32] [lib64] [lib_only]
+# syntax: make-lib.sh [debug] [macos-no-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -12,12 +12,11 @@ usage()
   echo "         macos-no-universal: do not build MacOS universal binaries"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
-  echo "         lib64: install Linux x64 libraries in \$PREFIX/lib64 (Fedora/Redhat/Suse, etc)"
   echo ""
 }
 
 . "$(dirname "$0")"/make-common.sh
 
-cmake -DBUILD_LIBS_ONLY=$BUILD_LIBS_ONLY -DLLVM_BUILD_32_BITS="$LLVM_BUILD_32_BITS" -DLLVM_LIBDIR_SUFFIX="$LLVM_LIBDIR_SUFFIX" -DCMAKE_OSX_ARCHITECTURES="$ARCH" -DCMAKE_BUILD_TYPE=$BUILDTYPE -DBUILD_SHARED_LIBS=OFF -DLLVM_TARGETS_TO_BUILD="all" -G "Unix Makefiles" ..
+cmake -DBUILD_LIBS_ONLY=$BUILD_LIBS_ONLY -DLLVM_BUILD_32_BITS="$LLVM_BUILD_32_BITS" -DCMAKE_OSX_ARCHITECTURES="$ARCH" -DCMAKE_BUILD_TYPE=$BUILDTYPE -DBUILD_SHARED_LIBS=OFF -DLLVM_TARGETS_TO_BUILD="all" -G "Unix Makefiles" ..
 
 time make -j8

--- a/make-share.sh
+++ b/make-share.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build shared library of Keystone Engine
-# syntax: make-share.sh [debug] [macos-no-universal] [lib32] [lib64] [lib_only]
+# syntax: make-share.sh [debug] [macos-no-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -12,12 +12,11 @@ usage()
   echo "         macos-no-universal: do not build MacOS universal binaries"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
-  echo "         lib64: install Linux x64 libraries in \$PREFIX/lib64 (Fedora/Redhat/Suse, etc)"
   echo ""
 }
 
 . "$(dirname "$0")"/make-common.sh
 
-cmake -DBUILD_LIBS_ONLY=$BUILD_LIBS_ONLY -DLLVM_BUILD_32_BITS="$LLVM_BUILD_32_BITS" -DLLVM_LIBDIR_SUFFIX="$LLVM_LIBDIR_SUFFIX" -DCMAKE_OSX_ARCHITECTURES="$ARCH" -DCMAKE_BUILD_TYPE=$BUILDTYPE -DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD="all" -G "Unix Makefiles" ..
+cmake -DBUILD_LIBS_ONLY=$BUILD_LIBS_ONLY -DLLVM_BUILD_32_BITS="$LLVM_BUILD_32_BITS" -DCMAKE_OSX_ARCHITECTURES="$ARCH" -DCMAKE_BUILD_TYPE=$BUILDTYPE -DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD="all" -G "Unix Makefiles" ..
 
 make -j8


### PR DESCRIPTION
When compiling on linux, use GNUInstallDirs to automatically determine
the appropriate libdir path for multi-arch builds instead of hardcoding
lib/ or lib64/. GNUInstallDirs should follow the FHS appropriately for
non-debian platforms that place libs in lib64/. This also removes the
need to specify `lib64` on the command line when building for a
non-debian system that follows the linux FHS.

When compiling with cmake directly on debian and specifying
`-DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_LIBRARY_ARCHITECTURE=<arch>`, the
libdir should be set to `/usr/lib/<arch>/`.