### PR TITLE
Fix minor spelling errors in libkeystone

### DIFF
--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -49,7 +49,7 @@ const char *ks_strerror(ks_err code)
 {
     switch(code) {
         default:
-            return "Unknow error";  // FIXME
+            return "Unknown error";  // FIXME
         case KS_ERR_OK:
             return "OK (KS_ERR_OK)";
         case KS_ERR_NOMEM:

--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -413,7 +413,7 @@ bool ELFAsmParser::ParseSectionArguments(bool IsPush, SMLoc loc)
     bool Mergeable = Flags & ELF::SHF_MERGE;
     bool Group = Flags & ELF::SHF_GROUP;
     if (Group && UseLastGroup)
-      return TokError("Section cannot specifiy a group name while also acting "
+      return TokError("Section cannot specify a group name while also acting "
                       "as a member of the last group");
 
     if (getLexer().isNot(AsmToken::Comma)) {

--- a/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
+++ b/llvm/lib/Target/Hexagon/AsmParser/HexagonAsmParser.cpp
@@ -1231,11 +1231,11 @@ bool HexagonAsmParser::isLabel(AsmToken &Token, bool &valid) {
 
 bool HexagonAsmParser::handleNoncontigiousRegister(bool Contigious, SMLoc &Loc) {
   if (!Contigious && ErrorNoncontigiousRegister) {
-    Error(Loc, "Register name is not contigious");
+    Error(Loc, "Register name is not contiguous");
     return true;
   }
   if (!Contigious && WarnNoncontigiousRegister)
-    Warning(Loc, "Register name is not contigious");
+    Warning(Loc, "Register name is not contiguous");
   return false;
 }
 


### PR DESCRIPTION
Fix some minor spelling errors in string constants.