### PR TITLE
Default to hidden symbol visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ if (POLICY CMP0051)
   cmake_policy(SET CMP0051 OLD)
 endif()
 
+if (POLICY CMP0063)
+  set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # automatic when 3.3.2 is required
+endif()
+
 if (CMAKE_VERSION VERSION_LESS 3.1.20141117)
   set(cmake_3_2_USES_TERMINAL)
 else()
@@ -38,6 +42,9 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /EHsc")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /EHsc")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /EHsc")
+else()
+    set(CMAKE_C_VISIBILITY_PRESET hidden)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 endif()
 
 # Force static runtime libraries


### PR DESCRIPTION
Default to hidden symbol visibility to reduce the number of public symbols in libkeystone.so. Reduces the number of defined public symbols from 2093 to 26.

There are still about 14 weak c++ symbols that I can't seem to figure out how to hide. They seem to all be related to instantiations of STL containers.

#### master
```
user@debian:~/keystone/build$ mkdir build && cd build && ../make-share.sh
...
user@debian:~/keystone/build$ readelf --dyn-syms llvm/lib/libkeystone.so.0 | grep -v ' 0 ' | wc -l
2093
user@debian:~/keystone/build$ readelf --dyn-syms llvm/lib/libkeystone.so.0 | grep -v ' 0 ' | grep -v 'WEAK' | wc -l
1805
```

#### hidden-symbol-visibility
```
user@debian:~/keystone/build$ mkdir build && cd build && ../make-share.sh
...
user@debian:~/keystone/build$ readelf --dyn-syms llvm/lib/libkeystone.so.0 | grep -v ' 0 ' | wc -l
26
user@debian:~/keystone/build$ readelf --dyn-syms llvm/lib/libkeystone.so.0 | grep -v ' 0 ' | grep -v 'WEAK' | wc -l
12
user@debian:~/keystone/build$ readelf --dyn-syms llvm/lib/libkeystone.so.0 | grep -v ' 0 ' | grep -v 'WEAK'

Symbol table '.dynsym' contains 139 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
   112: 00000000002ab050  1000 FUNC    GLOBAL DEFAULT   12 ks_strerror
   117: 00000000002ac540   169 FUNC    GLOBAL DEFAULT   12 ks_option
   120: 00000000002ab450  4026 FUNC    GLOBAL DEFAULT   12 ks_open
   122: 00000000002ab020    28 FUNC    GLOBAL DEFAULT   12 ks_version
   125: 00000000002ac5f0     5 FUNC    GLOBAL DEFAULT   12 ks_free
   128: 00000000002ac600  1742 FUNC    GLOBAL DEFAULT   12 ks_asm
   134: 00000000002ab440    10 FUNC    GLOBAL DEFAULT   12 ks_arch_supported
   135: 00000000002ab040     4 FUNC    GLOBAL DEFAULT   12 ks_errno
   138: 00000000002ac410   302 FUNC    GLOBAL DEFAULT   12 ks_close
```

#### Weak c++ symbols remaining (after running through `c++filt`)
```
std::_Rb_tree<std::pair<unsigned int, bool>, std::pair<unsigned int, bool>, std::_Identity<std::pair<unsigned int, bool> >, std::less<std::pair<unsigned int, bool> >, std::allocator<std::pair<unsigned int, bool> > >::count(std::pair<unsigned int, bool> const&) const
char* std::_V2::__rotate<char*>(char*, char*, char*, std::random_access_iterator_tag)
void std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::_M_realloc_insert<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(__gnu_cxx::__normal_iterator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::~vector()
std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::~vector()
void std::vector<char const*, std::allocator<char const*> >::emplace_back<char const*>(char const*&&)
std::_Rb_tree<std::pair<unsigned int, bool>, std::pair<unsigned int, bool>, std::_Identity<std::pair<unsigned int, bool> >, std::less<std::pair<unsigned int, bool> >, std::allocator<std::pair<unsigned int, bool> > >::_M_erase(std::_Rb_tree_node<std::pair<unsigned int, bool> >*)
std::_Rb_tree<unsigned int, std::pair<unsigned int const, unsigned int>, std::_Select1st<std::pair<unsigned int const, unsigned int> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, unsigned int> > >::_M_erase(std::_Rb_tree_node<std::pair<unsigned int const, unsigned int> >*)
std::pair<std::_Rb_tree_iterator<unsigned int>, bool> std::_Rb_tree<unsigned int, unsigned int, std::_Identity<unsigned int>, std::less<unsigned int>, std::allocator<unsigned int> >::_M_insert_unique<unsigned int const&>(unsigned int const&)
std::pair<std::_Rb_tree_iterator<unsigned int>, bool> std::_Rb_tree<unsigned int, unsigned int, std::_Identity<unsigned int>, std::less<unsigned int>, std::allocator<unsigned int> >::_M_insert_unique<unsigned int>(unsigned int&&)
std::_Rb_tree<unsigned int, unsigned int, std::_Identity<unsigned int>, std::less<unsigned int>, std::allocator<unsigned int> >::_M_erase(std::_Rb_tree_node<unsigned int>*)
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::operator+<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::operator+<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > std::operator+<char, std::char_traits<char>, std::allocator<char> >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
```