### PR TITLE
Update Debian packaging to Ubuntu 18.04

### DIFF
--- a/debian/keystone-engine-dev.dirs
+++ b/debian/keystone-engine-dev.dirs
@@ -1,2 +1,2 @@
 usr/lib
-usr/include/keystone
+usr/include

--- a/debian/keystone-engine-dev.install
+++ b/debian/keystone-engine-dev.install
@@ -1,3 +1,3 @@
 usr/include/keystone/*.h
-usr/lib/libkeystone.so
-usr/lib/pkgconfig/keystone.pc
+usr/lib/*/libkeystone.so
+usr/lib/*/pkgconfig/keystone.pc

--- a/debian/keystone-engine1.install
+++ b/debian/keystone-engine1.install
@@ -1,2 +1,2 @@
-usr/lib/libkeystone.so.*
+usr/lib/*/libkeystone.so.*
 usr/bin/kstool


### PR DESCRIPTION
The new version of Ubuntu (and associated cmake, ...) puts the libraries in /usr/lib/x86_64-linux-gnu, breaking the existing packaging.