### PR TITLE
bindings/rust: Fixed some stdc++ undefined references

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -6,6 +6,7 @@ description = "Rust bindings for the keystone-engine"
 license = "GPL-2.0"
 readme = "README.md"
 include = ["src/*", "tests/*", "Cargo.toml", "COPYING", "README.md"]
+build = "build.rs"
 
 [dependencies]
 libc = "0.2.*"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-flags=-l dylib=stdc++");
+}


### PR DESCRIPTION
This should fix undefined references errors concerning the libstdc++.
This has only been tested on Ubuntu 18.04.

I had these couple of errors:
```
= note: //usr/local/lib/libkeystone.a(ks.cpp.o): In function `_GLOBAL__sub_I_ks.cpp':
          ks.cpp:(.text.startup._GLOBAL__sub_I_ks.cpp+0xa): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()'
          //usr/local/lib/libkeystone.a(ks.cpp.o):(.data.DW.ref.__gxx_personality_v0[DW.ref.__gxx_personality_v0]+0x0): undefined reference to `__gxx_personality_v0'
          //usr/local/lib/libkeystone.a(AArch64MCTargetDesc.cpp.o): In function `llvm_ks::FeatureBitset::FeatureBitset(std::initializer_list<unsigned int>)':
          AArch64MCTargetDesc.cpp:(.text._ZN7llvm_ks13FeatureBitsetC2ESt16initializer_listIjE[_ZN7llvm_ks13FeatureBitsetC5ESt16initializer_listIjE]+0x6e): undefined reference to `std::__throw_out_of_range_fmt(char const*, ...)'
          //usr/local/lib/libkeystone.a(MipsAsmParser.cpp.o): In function `_GLOBAL__sub_I_MipsAsmParser.cpp':
          MipsAsmParser.cpp:(.text.startup._GLOBAL__sub_I_MipsAsmParser.cpp+0x86): undefined reference to `std::__throw_out_of_range_fmt(char const*, ...)'
          //usr/local/lib/libkeystone.a(HexagonMCDuplexInfo.cpp.o): In function `std::_Rb_tree<unsigned int, std::pair<unsigned int const, unsigned int>, std::_Select1st<std::pair<unsigned int const, unsigned int> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, unsigned int> > >::_M_erase(std::_Rb_tree_node<std::pair<unsigned int const, unsigned int> >*)':
          HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0xa3): undefined reference to `operator delete(void*)'
          HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0xb7): undefined reference to `operator delete(void*)'
          HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0xcc): undefined reference to `operator delete(void*)'
          HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0xe0): undefined reference to `operator delete(void*)'
          HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0xf6): undefined reference to `operator delete(void*)'
          //usr/local/lib/libkeystone.a(HexagonMCDuplexInfo.cpp.o):HexagonMCDuplexInfo.cpp:(.text._ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E[_ZNSt8_Rb_treeIjSt4pairIKjjESt10_Select1stIS2_ESt4lessIjESaIS2_EE8_M_eraseEPSt13_Rb_tree_nodeIS2_E]+0x115): more undefined references to `operator delete(void*)' follow
          //usr/local/lib/libkeystone.a(HexagonMCDuplexInfo.cpp.o): In function `_GLOBAL__sub_I_HexagonMCDuplexInfo.cpp':
          HexagonMCDuplexInfo.cpp:(.text.startup._GLOBAL__sub_I_HexagonMCDuplexInfo.cpp+0xca): undefined reference to `operator new(unsigned long)'
          HexagonMCDuplexInfo.cpp:(.text.startup._GLOBAL__sub_I_HexagonMCDuplexInfo.cpp+0xec): undefined reference to `std::_Rb_tree_insert_and_rebalance(bool, std::_Rb_tree_node_base*, std::_Rb_tree_node_base*, std::_Rb_tree_node_base&)'
          HexagonMCDuplexInfo.cpp:(.text.startup._GLOBAL__sub_I_HexagonMCDuplexInfo.cpp+0x15c): undefined reference to `std::_Rb_tree_decrement(std::_Rb_tree_node_base*)'
          //usr/local/lib/libkeystone.a(MCFragment.cpp.o): In function `llvm_ks::MCFragment::MCFragment(llvm_ks::MCFragment::FragmentType, bool, unsigned char, llvm_ks::MCSection*)':
          MCFragment.cpp:(.text._ZN7llvm_ks10MCFragmentC2ENS0_12FragmentTypeEbhPNS_9MCSectionE+0x8b): undefined reference to `operator new(unsigned long)'
          collect2: error: ld returned 1 exit status
```