### PR TITLE
Don't build universal binaries by default

### DIFF
--- a/make-common.sh
+++ b/make-common.sh
@@ -21,6 +21,9 @@ while [ "$1" != "" ]; do
     debug)
       BUILDTYPE='Debug'
       ;;
+    macos-no-universal)
+      ARCH=''	# do not build MacOS universal binaries
+      ;;
     macos-universal)
       ARCH='i386;x86_64'	# build MacOS universal binaries
       ;;

--- a/make-common.sh
+++ b/make-common.sh
@@ -1,7 +1,7 @@
 BUILDTYPE='Release'
 
-# on MacOS, build universal binaries by default
-ARCH='i386;x86_64'
+# on MacOS, do not build universal binaries by default
+ARCH=''
 
 # by default we do NOT build 32bit on 64bit system
 LLVM_BUILD_32_BITS=0
@@ -21,8 +21,8 @@ while [ "$1" != "" ]; do
     debug)
       BUILDTYPE='Debug'
       ;;
-    macos-no-universal)
-      ARCH=''	# do not build MacOS universal binaries
+    macos-universal)
+      ARCH='i386;x86_64'	# build MacOS universal binaries
       ;;
     *)
       echo "ERROR: unknown parameter \"$1\""

--- a/make-lib.sh
+++ b/make-lib.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build static library of Keystone Engine
-# syntax: make-lib.sh [debug] [macos-no-universal] [lib32] [lib_only]
+# syntax: make-lib.sh [debug] [macos-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -9,7 +9,7 @@ usage()
   echo "Syntax:  make-lib.sh [debug] [macos-universal] [lib64]"
   echo ""
   echo "         debug: build with debug info"
-  echo "         macos-no-universal: do not build MacOS universal binaries"
+  echo "         macos-universal: build MacOS universal binaries"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
   echo ""

--- a/make-lib.sh
+++ b/make-lib.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build static library of Keystone Engine
-# syntax: make-lib.sh [debug] [macos-universal] [lib32] [lib_only]
+# syntax: make-lib.sh [debug] [macos-universal|macos-no-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -10,6 +10,7 @@ usage()
   echo ""
   echo "         debug: build with debug info"
   echo "         macos-universal: build MacOS universal binaries"
+  echo "         macos-no-universal: do not build MacOS universal binaries (default)"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
   echo ""

--- a/make-share.sh
+++ b/make-share.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build shared library of Keystone Engine
-# syntax: make-share.sh [debug] [macos-no-universal] [lib32] [lib_only]
+# syntax: make-share.sh [debug] [macos-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -9,7 +9,7 @@ usage()
   echo "Syntax:  make-share.sh [debug] [macos-universal] [lib64]"
   echo ""
   echo "         debug: build with debug info"
-  echo "         macos-no-universal: do not build MacOS universal binaries"
+  echo "         macos-universal: build MacOS universal binaries"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
   echo ""

--- a/make-share.sh
+++ b/make-share.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 # Build shared library of Keystone Engine
-# syntax: make-share.sh [debug] [macos-universal] [lib32] [lib_only]
+# syntax: make-share.sh [debug] [macos-universal|macos-no-universal] [lib32] [lib_only]
 
 usage()
 {
@@ -10,6 +10,7 @@ usage()
   echo ""
   echo "         debug: build with debug info"
   echo "         macos-universal: build MacOS universal binaries"
+  echo "         macos-no-universal: do not build MacOS universal binaries (default)"
   echo "         lib_only: skip kstool & only build libraries"
   echo "         lib32: build 32bit libraries on 64bit system"
   echo ""


### PR DESCRIPTION
Starting Xcode 10 beta, there's no support for i386.
This commit changes the default build on iOS to regular libraries
instead of universal binaries.
Build of universal binaries is still supported with macos-universal.