### PR TITLE
fix gcc's memaccess warning

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -337,7 +337,7 @@ public:
   void push_back(const T &Elt) {
     if (LLVM_UNLIKELY(this->EndX >= this->CapacityX))
       this->grow();
-    memcpy(this->end(), &Elt, sizeof(T));
+    memcpy(reinterpret_cast<void *>(this->end()), &Elt, sizeof(T));
     this->setEnd(this->end()+1);
   }
 


### PR DESCRIPTION
Hello all,
This PR tries to make gcc 8 happy with its `class-memaccess` check, a similar fix has been [done](https://github.com/llvm-mirror/llvm/blob/master/include/llvm/ADT/SmallVector.h#L313) by LLVM.