### PR TITLE
test+fix thumb backwards branching with sym_resolver (#355)

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -699,7 +699,7 @@ void ARMAsmBackend::processFixupValue(const MCAssembler &Asm,
 
     // If the symbol is out of range, produce a relocation and hope the
     // linker can handle it. GNU AS produces an error in this case.
-    if (Sym->isExternal() || Value >= 0x400004)
+    if (Sym->isExternal() || ((Value >= 0x400004) && (Value <= (uint64_t)(-0x400000))))
       IsResolved = false;
   }
   // We must always generate a relocation for BL/BLX instructions if we have

--- a/suite/regress/arm_sym_resolver.py
+++ b/suite/regress/arm_sym_resolver.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+# Test BL <symbol> instruction with KS_OPT_SYM_RESOLVER for ARM32
+
+# Github issue: #355
+# Author: jan2642
+
+from keystone import *
+
+import regress
+
+class TestARM(regress.RegressTest):
+    def runTest(self):
+        def sym_resolver(symbol, value):
+            if symbol == "symBackward":
+                value[0] = 0x0
+                return True
+
+            if symbol == "symForward":
+                value[0] = 0x20
+                return True
+
+            return False
+
+        # Initialize Keystone engine
+        ks = Ks(KS_ARCH_ARM, KS_MODE_ARM)
+        ks.sym_resolver = sym_resolver
+
+        encoding, _ = ks.asm(b"""
+                    sub r0, r0, r0
+                    sub r1, r1, r1
+                    bl  symBackward
+                    """)
+        self.assertEqual(encoding[-4:], [ 0xfc, 0xff, 0xff, 0xeb ])
+
+        encoding, _ = ks.asm(b"bl  symForward")
+        self.assertEqual(encoding, [ 0x06, 0x00, 0x00, 0xeb ])
+
+if __name__ == '__main__':
+    regress.main()

--- a/suite/regress/arm_sym_resolver_thumb.py
+++ b/suite/regress/arm_sym_resolver_thumb.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+# Test BL <symbol> instruction with KS_OPT_SYM_RESOLVER for THUMB
+
+# Github issue: #355
+# Author: jan2642
+
+from keystone import *
+
+import regress
+
+class TestARM(regress.RegressTest):
+    def runTest(self):
+        def sym_resolver(symbol, value):
+            if symbol == "symBackward":
+                value[0] = 0x0
+                return True
+
+            if symbol == "symForward":
+                value[0] = 0x20
+                return True
+
+            return False
+
+        # Initialize Keystone engine
+        ks = Ks(KS_ARCH_ARM, KS_MODE_THUMB)
+        ks.sym_resolver = sym_resolver
+
+        encoding, _ = ks.asm(b"""
+                    sub r0, r0, r0
+                    sub r0, r0, r0
+                    bl  symBackward
+                    """)
+        self.assertEqual(encoding[-4:], [ 0xff, 0xf7, 0xfa, 0xff ])
+
+        encoding, _ = ks.asm(b"bl  symForward")
+        self.assertEqual(encoding, [ 0x00, 0xf0, 0x0e, 0xf8 ])
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
When branching backwards in thumb to a sym_resolved symbol, the instruction was always encoded as "bl #0" because negative offset were rejected.

I've added tests for both ARM32 and THUMB where sym_resolve is used for jumping back & forward. The THUMB test fails without the fix in ARMAsmBackend.cpp and passes with the fix.