### PR TITLE
Avoids overflow with multiplication

### DIFF
--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -781,7 +781,12 @@ bool MCExpr::evaluateAsRelocatableImpl(MCValue &Res, const MCAssembler *Asm,
         return false;
       Result = LHS % RHS;
       break;
-    case MCBinaryExpr::Mul:  Result = LHS * RHS; break;
+    case MCBinaryExpr::Mul:
+        // Avoid overflow
+        if (LHS != 0 && RHS > LLONG_MAX / LHS) {
+            return false;
+        }
+        Result = LHS * RHS; break;
     case MCBinaryExpr::NE:   Result = LHS != RHS; break;
     case MCBinaryExpr::Or:   Result = LHS | RHS; break;
     case MCBinaryExpr::Shl:  Result = uint64_t(LHS) << uint64_t(RHS); break;


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10424

This comes from input ".3*3" 
Should we rather handle somehow handle types so that we do a float multiplication ? instead of a uint64 multiplication of the float encoded into uint64...