### PR TITLE
Limit recursion with fragments depth

### DIFF
--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -43,6 +43,9 @@ using namespace llvm_ks;
 
 /* *** */
 
+static unsigned FragmentsDepth = 0;
+
+
 MCAssembler::MCAssembler(MCContext &Context_, MCAsmBackend &Backend_,
                          MCCodeEmitter &Emitter_, MCObjectWriter &Writer_)
     : Context(Context_), Backend(Backend_), Emitter(Emitter_), Writer(Writer_),
@@ -265,6 +268,11 @@ bool MCAssembler::evaluateFixup(const MCAsmLayout &Layout,
 uint64_t MCAssembler::computeFragmentSize(const MCAsmLayout &Layout,
                                           const MCFragment &F, bool &valid) const
 {
+  FragmentsDepth++;
+  if (FragmentsDepth > 0x10) {
+    valid = false;
+    return 0;
+  }
   valid = true;
   switch (F.getKind()) {
   case MCFragment::FT_Data:


### PR DESCRIPTION
As found with https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10447

Recursion loops over 
```

#239 0x592b9d in llvm_ks::MCAssembler::computeFragmentSize(llvm_ks::MCAsmLayout const&, llvm_ks::MCFragment const&, bool&) const keystone/llvm/lib/MC/MCAssembler.cpp:320:19
--
  | #240 0x593634 in llvm_ks::MCAsmLayout::layoutFragment(llvm_ks::MCFragment*) keystone/llvm/lib/MC/MCAssembler.cpp:367:47
  | #241 0x964e8e in llvm_ks::MCAsmLayout::ensureValid(llvm_ks::MCFragment const*) const keystone/llvm/lib/MC/MCFragment.cpp:76:42
  | #242 0x965051 in llvm_ks::MCAsmLayout::getFragmentOffset(llvm_ks::MCFragment const*, bool&) const keystone/llvm/lib/MC/MCFragment.cpp:87:8
  | #243 0x968794 in getLabelOffset(llvm_ks::MCAsmLayout const&, llvm_ks::MCSymbol const&, bool, unsigned long&) keystone/llvm/lib/MC/MCFragment.cpp:112:16
  | #244 0x9652fa in getSymbolOffsetImpl(llvm_ks::MCAsmLayout const&, llvm_ks::MCSymbol const&, bool, unsigned long&, bool&) keystone/llvm/lib/MC/MCFragment.cpp:122:12
  | #245 0x592b9d in llvm_ks::MCAssembler::computeFragmentSize(llvm_ks::MCAsmLayout const&, llvm_ks::MCFragment const&, bool&) const keystone/llvm/lib/MC/MCAssembler.cpp:320:19

```