### PR TITLE
Fix ADRP instruction encoding

### DIFF
--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -1133,7 +1133,7 @@ public:
         return false;
 
     if (const MCConstantExpr *CE = dyn_cast<MCConstantExpr>(Imm.Val)) {
-      int64_t Val = CE->getValue() - Ctx.getBaseAddress();
+      int64_t Val = CE->getValue();
       int64_t Min = - (4096 * (1LL << (21 - 1)));
       int64_t Max = 4096 * ((1LL << (21 - 1)) - 1);
       return (Val % 4096) == 0 && Val >= Min && Val <= Max;

--- a/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
+++ b/llvm/lib/Target/AArch64/AsmParser/AArch64AsmParser.cpp
@@ -1134,9 +1134,10 @@ public:
 
     if (const MCConstantExpr *CE = dyn_cast<MCConstantExpr>(Imm.Val)) {
       int64_t Val = CE->getValue();
+      int64_t Offset = Val - Ctx.getBaseAddress();
       int64_t Min = - (4096 * (1LL << (21 - 1)));
       int64_t Max = 4096 * ((1LL << (21 - 1)) - 1);
-      return (Val % 4096) == 0 && Val >= Min && Val <= Max;
+      return (Val % 4096) == 0 && Offset >= Min && Offset <= Max;
     }
 
     return true;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCCodeEmitter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCCodeEmitter.cpp
@@ -219,7 +219,7 @@ AArch64MCCodeEmitter::getAdrLabelOpValue(const MCInst &MI, unsigned OpIdx,
 
   // If the destination is an immediate, we have nothing to do.
   if (MO.isImm())
-      return (MO.getImm() * 4096 - MI.getAddress()) / 4096;
+      return MO.getImm() - (MI.getAddress() >> 12);
   assert(MO.isExpr() && "Unexpected target type!");
   const MCExpr *Expr = MO.getExpr();
 


### PR DESCRIPTION
Currently, ADRP instructions on AArch64 will fail under some situations:

    $ ./kstool/kstool arm64 "adrp   x2, #0x5C6000" 0x100
    ERROR: failed on ks_asm() with count = 0, error = 'Unknown error' (code = 539)

This change fixes that (the change in AArch64AsmParser.cpp).

Additionally, this fixes an off-by-one error in AArch64MCCodeEmitter.cpp

**Before**

    $ ./kstool/kstool arm64 "adrp   x2, #0x5C6000" 0x100
    adrp   x2, #0x5C6000 = [ 22 2e 00 b0 ]
    $ cstool arm64 "22 2e 00 b0" 0x100
    100  22 2e 00 b0  adrp	x2, #0x5c5000

**After**

    $ ./kstool/kstool arm64 "adrp   x2, #0x5C6000" 0x100
    adrp   x2, #0x5C6000 = [ 22 2e 00 d0 ]
    $ cstool arm64 "22 2e 00 d0" 0x100
    100  22 2e 00 d0  adrp	x2, #0x5c6000
