### PR TITLE
Various improvements to the Rust bindings

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keystone"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
   "Remco Verhoef <remco.verhoef@dutchcoders.io>",
   "Tasuku SUENAGA a.k.a. gunyarakun <tasuku-s-github@titech.ac>"
@@ -17,7 +17,7 @@ include = [
 [dependencies]
 bitflags = "1.0"
 libc = "0.2"
-keystone-sys = { path = "keystone-sys", version = "0.9.1" }
+keystone-sys = { path = "keystone-sys", version = "0.10.0" }
 
 [features]
 default = []

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -10,16 +10,17 @@ license = "GPL-2.0"
 readme = "README.md"
 repository = "https://github.com/keystone-engine/keystone"
 include = [
-  "src/*", "tests/*", "Cargo.toml", "COPYING", "README.md",
-  "keystone-sys/*"
+  "src/*", "tests/*", "Cargo.toml", "COPYING", "README.md"
 ]
 
 [dependencies]
 libc = "0.2"
-keystone-sys = { path = "keystone-sys", version = "0.10.0" }
+keystone-sys = { path = "keystone-sys", version = "0.10" }
 
 [features]
 default = []
 
 use_system_keystone = ["keystone-sys/use_system_keystone"]
 build_keystone_cmake = ["keystone-sys/build_keystone_cmake"]
+
+[workspace]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -15,7 +15,6 @@ include = [
 ]
 
 [dependencies]
-bitflags = "1.0"
 libc = "0.2"
 keystone-sys = { path = "keystone-sys", version = "0.10.0" }
 

--- a/bindings/rust/Makefile
+++ b/bindings/rust/Makefile
@@ -2,14 +2,19 @@
 
 .PHONY: gen_const build package clean check
 
-build:
+build: keystone-sys/keystone
 	cargo build -vv
 
-package:
+package: keystone-sys/keystone
 	cd keystone-sys && cargo package -vv
 	cargo package -vv
 
+# For packaging we need to embed the keystone source in the crate
+keystone-sys/keystone:
+	rsync -a ../.. keystone-sys/keystone --exclude bindings --filter ":- ../../.gitignore"
+
 clean:
+	rm -rf keystone-sys/keystone/
 	cargo clean
 
 check:

--- a/bindings/rust/Makefile
+++ b/bindings/rust/Makefile
@@ -2,22 +2,20 @@
 
 .PHONY: gen_const build package clean check
 
-build: keystone-sys/keystone
+build:
 	cargo build -vv
 
-package: keystone-sys/keystone
+package:
 	cd keystone-sys && cargo package -vv
 	cargo package -vv
 
-keystone-sys/keystone:
-	rsync -a ../.. keystone-sys/keystone --exclude bindings --filter ":- ../../.gitignore"
-
 clean:
-	rm -rf target/ keystone-sys/target/ keystone-sys/keystone/
+	cargo clean
 
 check:
-	cargo test
+# 	Make sure to only use one test thread as keystone isn't thread-safe
+	cargo test -- --test-threads=1
 
 gen_const:
-	cd .. && python const_generator.py rust
+	cd .. && python2 const_generator.py rust
 	cargo fmt

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -39,6 +39,7 @@ If you want to use keystone already installed in the system, specify `use_system
 ```
 [dependencies.keystone]
 version = "0.10.0"
+default-features = false
 features = ["use_system_keystone"]
 ```
 

--- a/bindings/rust/keystone-sys/Cargo.toml
+++ b/bindings/rust/keystone-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keystone-sys"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
   "Remco Verhoef <remco.verhoef@dutchcoders.io>",
   "Tasuku SUENAGA a.k.a. gunyarakun <tasuku-s-github@titech.ac>"

--- a/bindings/rust/keystone-sys/Cargo.toml
+++ b/bindings/rust/keystone-sys/Cargo.toml
@@ -15,8 +15,6 @@ exclude = [
 ]
 
 [build-dependencies]
-build-helper = "0.1"
-os_type = "2.0"
 pkg-config = { optional = true, version = "0.3" }
 
 [dependencies]

--- a/bindings/rust/keystone-sys/Cargo.toml
+++ b/bindings/rust/keystone-sys/Cargo.toml
@@ -10,21 +10,17 @@ repository = "https://github.com/keystone-engine/keystone"
 documentation = "https://docs.rs/keystone/"
 license = "GPL-2.0"
 build = "build.rs"
-exclude = [
-  "keystone/build/**"
-]
 
 [build-dependencies]
 pkg-config = { optional = true, version = "0.3" }
+cmake = { optional = true, version = "0.1" }
 
 [dependencies]
 bitflags = "1.0"
 libc = "0.2"
 
 [features]
-default = []
+default = ["build_keystone_cmake"]
 
 use_system_keystone = ["pkg-config"]
-build_keystone_cmake = []
-
-[workspace]
+build_keystone_cmake = ["cmake"]

--- a/bindings/rust/keystone-sys/Cargo.toml
+++ b/bindings/rust/keystone-sys/Cargo.toml
@@ -28,3 +28,5 @@ default = []
 
 use_system_keystone = ["pkg-config"]
 build_keystone_cmake = []
+
+[workspace]

--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -24,7 +24,7 @@ fn build_with_cmake() {
     let dest = cmake::Config::new("keystone")
         .define("BUILD_LIBS_ONLY", "1")
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("LLVM_TARGET_ARCH", "host")
+        .define("LLVM_TARGETS_TO_BUILD", "all")
         // Prevent python from leaving behind `.pyc` files which break `cargo package`
         .env("PYTHONDONTWRITEBYTECODE", "1")
         .build();

--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -1,41 +1,30 @@
+#[cfg(feature = "build_keystone_cmake")]
+extern crate cmake;
 #[cfg(feature = "use_system_keystone")]
 extern crate pkg_config;
 
-use std::env;
-use std::path::PathBuf;
-use std::process::Command;
+#[cfg(feature = "build_keystone_cmake")]
+use std::os::unix::fs;
+#[cfg(feature = "build_keystone_cmake")]
+use std::path::Path;
 
+#[cfg(feature = "build_keystone_cmake")]
 fn build_with_cmake() {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let cmake_dir = PathBuf::from("keystone");
-    let build_dir = cmake_dir.join("build");
-
-    if !cmake_dir.exists() {
-        run(Command::new("ln").arg("-s").arg("../../..").arg("keystone"));
+    if !Path::new("keystone").exists() {
+        // This only happens when using the crate via a `git` reference as the
+        // published version already embeds keystone's source.
+        fs::symlink("../../..", "keystone").expect("failed to symlink keystone");
     }
 
-    run(Command::new("mkdir")
-        .current_dir(&cmake_dir)
-        .arg("-p")
-        .arg("build"));
+    let dest = cmake::Config::new("keystone")
+        .define("BUILD_LIBS_ONLY", "1")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("LLVM_TARGET_ARCH", "host")
+        // Prevent python from leaving behind `.pyc` files which break `cargo package`
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .build();
 
-    run(Command::new("../make-share.sh").current_dir(&build_dir));
-
-    run(Command::new("cmake").current_dir(&build_dir).args(&[
-        &format!("-DCMAKE_INSTALL_PREFIX={}", out_dir.display()),
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DBUILD_LIBS_ONLY=1",
-        "-DCMAKE_OSX_ARCHITECTURES=",
-        "-DBUILD_SHARED_LIBS=ON",
-        "-DLLVM_TARGET_ARCH=host",
-        "-G",
-        "Unix Makefiles",
-        "..",
-    ]));
-
-    run(Command::new("make").current_dir(&build_dir).arg("install"));
-
-    println!("cargo:rustc-link-search=native={}/lib", out_dir.display());
+    println!("cargo:rustc-link-search=native={}/lib", dest.display());
     println!("cargo:rustc-link-lib=keystone");
 }
 
@@ -44,24 +33,7 @@ fn main() {
         #[cfg(feature = "use_system_keystone")]
         pkg_config::find_library("keystone").expect("Could not find system keystone");
     } else {
+        #[cfg(feature = "build_keystone_cmake")]
         build_with_cmake();
     }
-}
-
-fn run(cmd: &mut Command) {
-    println!("run: {:?}", cmd);
-    let status = match cmd.status() {
-        Ok(s) => s,
-        Err(ref e) => fail(&format!("failed to execute command: {}", e)),
-    };
-    if !status.success() {
-        fail(&format!(
-            "command did not execute successfully, got: {}",
-            status
-        ));
-    }
-}
-
-fn fail(s: &str) -> ! {
-    panic!("\n{}\n\nbuild script failed, must exit now", s);
 }

--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -16,7 +16,9 @@ fn build_with_cmake() {
     if !Path::new("keystone").exists() {
         // This only happens when using the crate via a `git` reference as the
         // published version already embeds keystone's source.
-        symlink("../../..", "keystone").expect("failed to symlink keystone");
+        let pwd = std::env::current_dir().unwrap();
+        let keystone_dir = pwd.ancestors().skip(3).next().unwrap();
+        symlink(keystone_dir, "keystone").expect("failed to symlink keystone");
     }
 
     let dest = cmake::Config::new("keystone")

--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -32,8 +32,14 @@ fn build_with_cmake() {
     println!("cargo:rustc-link-search=native={}/lib", dest.display());
     println!("cargo:rustc-link-lib=keystone");
 
-    #[cfg(windows)]
-    println!("cargo:rustc-link-lib=shell32");
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("apple") {
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else if target.contains("linux") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    } else if target.contains("windows") {
+        println!("cargo:rustc-link-lib=dylib=shell32");
+    }
 }
 
 fn main() {

--- a/bindings/rust/keystone-sys/src/lib.rs
+++ b/bindings/rust/keystone-sys/src/lib.rs
@@ -17,9 +17,8 @@ use keystone_const::{Arch, Error, Mode, OptionType, OptionValue};
 #[allow(non_camel_case_types)]
 pub type ks_handle = libc::size_t;
 
-#[link(name = "keystone")]
 extern "C" {
-    pub fn ks_version(major: *const u32, minor: *const u32) -> u32;
+    pub fn ks_version(major: *mut u32, minor: *mut u32) -> u32;
     pub fn ks_arch_supported(arch: Arch) -> bool;
     pub fn ks_open(arch: Arch, mode: Mode, engine: *mut ks_handle) -> Error;
     pub fn ks_asm(
@@ -38,8 +37,8 @@ extern "C" {
 }
 
 impl Error {
-    pub fn msg(&self) -> String {
-        error_msg(*self)
+    pub fn msg(self) -> String {
+        error_msg(self)
     }
 }
 

--- a/bindings/rust/keystone-sys/src/lib.rs
+++ b/bindings/rust/keystone-sys/src/lib.rs
@@ -9,10 +9,10 @@ extern crate libc;
 
 pub mod keystone_const;
 
-use std::fmt;
-use std::ffi::CStr;
-use std::os::raw::c_char;
 use keystone_const::{Arch, Error, Mode, OptionType, OptionValue};
+use std::ffi::CStr;
+use std::fmt;
+use std::os::raw::c_char;
 
 #[allow(non_camel_case_types)]
 pub type ks_handle = libc::size_t;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,6 +1,6 @@
-//! Keystone Assembler Engine (www.keystone-engine.org) */
-//! By Nguyen Anh Quynh <aquynh@gmail.com>, 2016 */
-//! Rust bindings by Remco Verhoef <remco@dutchcoders.io>, 2016 */
+//! Keystone Assembler Engine (www.keystone-engine.org) \
+//! By Nguyen Anh Quynh <aquynh@gmail.com>, 2016 \
+//! Rust bindings by Remco Verhoef <remco@dutchcoders.io>, 2016
 //!
 //! ```rust
 //! extern crate keystone;
@@ -15,8 +15,6 @@
 //!         .expect("Could not assemble");
 //! }
 //! ```
-
-#![doc(html_root_url = "https://keystone/doc/here/v1")]
 
 extern crate keystone_sys as ffi;
 extern crate libc;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -21,7 +21,7 @@
 extern crate keystone_sys as ffi;
 extern crate libc;
 
-use std::ffi::{CString, CStr};
+use std::ffi::{CStr, CString};
 use std::fmt;
 
 pub use ffi::keystone_const::*;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -21,7 +21,7 @@
 extern crate keystone_sys as ffi;
 extern crate libc;
 
-use std::ffi::CString;
+use std::ffi::{CString, CStr};
 use std::fmt;
 
 pub use ffi::keystone_const::*;
@@ -66,7 +66,7 @@ pub fn arch_supported(arch: Arch) -> bool {
 
 pub fn error_msg(error: Error) -> String {
     unsafe {
-        CStr::from_ptr(ffi::ks_strerror(error.bits()))
+        CStr::from_ptr(ffi::ks_strerror(error))
             .to_string_lossy()
             .into_owned()
     }


### PR DESCRIPTION
Just various small cleanups which should ultimately enable us to publish a new version again (or at least fix compilation). (The last release is from [2016](https://crates.io/crates/keystone)) @nl5887 are you still maintaining these bindings or are you willing to pass on the crates.io publishing rights to someone else?

cc #399 