### PR TITLE
add suite/ directory for suite/fuzz, fix python build

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -49,6 +49,7 @@ def copy_sources():
 
     dir_util.copy_tree("../../llvm", "src/llvm/")
     dir_util.copy_tree("../../include", "src/include/")
+    dir_util.copy_tree("../../suite", "src/suite")
 
     src.extend(glob.glob("../../*.h"))
     src.extend(glob.glob("../../*.cpp"))


### PR DESCRIPTION
Now CMakeLIsts.txt uses suite/fuzz for fuzzing, and currently sdist command doesn't work due to this reason. After adding suite/, it worked.

I've used `python setup.py sdist bdist; pip wheel .` for building a wheel package, but I'm not sure if it's right. Thank you for the great project!