### PR TITLE
Update keystone-binding.go to fix issue #363

### DIFF
--- a/bindings/go/keystone/keystone-binding.go
+++ b/bindings/go/keystone/keystone-binding.go
@@ -5,7 +5,7 @@
 // +build darwin,linux,cgo
 package keystone
 
-// #cgo LDFLAGS: -lkeystone
+// #cgo LDFLAGS: -lkeystone -lstdc++ -lm
 // #include <keystone/keystone.h>
 import "C"
 import "unsafe"


### PR DESCRIPTION
When trying to execute `make install` inside the go binding sample, the output shows an error that is specified by guitmz in issue #363 

Adding the missing cgo LDFLAGS resolves this issue.