### PR TITLE
Add -lstdc++ -lm flags for go binding build

### DIFF
--- a/bindings/go/keystone/keystone-binding.go
+++ b/bindings/go/keystone/keystone-binding.go
@@ -5,7 +5,7 @@
 // +build darwin,linux,cgo
 package keystone
 
-// #cgo LDFLAGS: -lkeystone
+// #cgo LDFLAGS: -lkeystone -lstdc++ -lm
 // #include <keystone/keystone.h>
 import "C"
 import "unsafe"


### PR DESCRIPTION
This fixes errors occurred when building my go application with a keystone static library.

```
...
StringTableBuilder.cpp:(.text._ZN4llvm18StringTableBuilder19finalizeStringTableEb+0x7b): undefined reference to `operator delete(void*)'
StringTableBuilder.cpp:(.text._ZN4llvm18StringTableBuilder19finalizeStringTableEb+0x2dc): undefined reference to `operator new(unsigned long)'
StringTableBuilder.cpp:(.text._ZN4llvm18StringTableBuilder19finalizeStringTableEb+0x2f2): undefined reference to `operator delete(void*)'
StringTableBuilder.cpp:(.text._ZN4llvm18StringTableBuilder19finalizeStringTableEb+0x685): undefined reference to `operator delete(void*)'
```

```
/usr/bin/ld: /.../llvm/lib/libkeystone.a(APInt.cpp.o): undefined reference to symbol 'sqrt@@GLIBC_2.2.5'
```

No problem to build with shared keystone library as well.

Tested in linux.