### PR TITLE
Fix Rust bindings

### DIFF
--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -32,7 +32,7 @@ template = {
             ]
         },
     'rust': {
-            'header': "#![allow(non_camel_case_types)]\n// For Keystone Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const.rs]\nuse libc;\n",
+            'header': "#![allow(non_camel_case_types)]\n// For Keystone Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const.rs]\nuse ::libc::*;\n",
             'footer': "",
             # prefixes for constant filenames of all archs - case sensitive
             'arm.h': 'keystone',
@@ -52,14 +52,14 @@ template = {
                 {
                     'regex': r'(API)_.*',
                     'pre': '\n',
-                    'line_format': 'pub const {0}: u32 = {1};\n',
+                    'line_format': 'pub const {0}: c_uint = {1};\n',
                     'fn': (lambda x: x),
                 },
                 {   'regex': r'MODE_.*',
                     'pre': '\n' +
                             'bitflags! {{\n' +
                             '#[repr(C)]\n' +
-                            '    pub struct Mode: u32 {{\n',
+                            '    pub struct Mode: c_int {{\n',
                     'line_format': '        const {0} = {1};\n',
                     'fn': (lambda x: '_'.join(x.split('_')[1:]) if not re.match(r'MODE_\d+', x) else x),
                     'post': '    }\n}',
@@ -87,7 +87,7 @@ template = {
                     'regex': r'OPT_(?!SYM)([A-Z]+\_)+[A-Z]+',
                     'pre': 'bitflags! {{\n'
                             '#[repr(C)]\n' +
-                            '    pub struct OptionValue: libc::size_t {{\n',
+                            '    pub struct OptionValue: size_t {{\n',
                     'line_format': '        const {0} = {1};\n',
                     'fn': (lambda x: '_'.join(x.split('_')[1:])),
                     'post': '    }\n}\n',
@@ -96,7 +96,7 @@ template = {
                     'regex': r'ERR_(.*)',
                     'pre': 'bitflags! {{\n' +
                             '#[repr(C)]\n' +
-                            '    pub struct Error: u32 {{\n',
+                            '    pub struct Error: c_int {{\n',
                     'line_format': '        const {0} = {1};\n',
                     'fn': (lambda x: '_'.join(x.split('_')[1:])),
                     'post': '    }\n}',

--- a/bindings/rust/keystone-sys/src/keystone_const.rs
+++ b/bindings/rust/keystone-sys/src/keystone_const.rs
@@ -1,13 +1,13 @@
 #![allow(non_camel_case_types)]
 // For Keystone Engine. AUTO-GENERATED FILE, DO NOT EDIT [keystone_const.rs]
-use libc;
+use ::libc::*;
 
-pub const API_MAJOR: u32 = 0;
-pub const API_MINOR: u32 = 9;
+pub const API_MAJOR: c_uint = 0;
+pub const API_MINOR: c_uint = 9;
 
 bitflags! {
 #[repr(C)]
-    pub struct Mode: u32 {
+    pub struct Mode: c_int {
         const LITTLE_ENDIAN = 0;
         const BIG_ENDIAN = 1073741824;
         const ARM = 1;
@@ -54,7 +54,7 @@ pub enum OptionType {
 
 bitflags! {
 #[repr(C)]
-    pub struct OptionValue: libc::size_t {
+    pub struct OptionValue: size_t {
         const SYNTAX_INTEL = 1;
         const SYNTAX_ATT = 2;
         const SYNTAX_NASM = 4;
@@ -66,7 +66,7 @@ bitflags! {
 
 bitflags! {
 #[repr(C)]
-    pub struct Error: u32 {
+    pub struct Error: c_int {
         const ASM = 128;
         const ASM_ARCH = 512;
         const OK = 0;

--- a/bindings/rust/keystone-sys/src/lib.rs
+++ b/bindings/rust/keystone-sys/src/lib.rs
@@ -2,6 +2,7 @@
 //! By Nguyen Anh Quynh <aquynh@gmail.com>, 2016 */
 //! Rust bindings by Remco Verhoef <remco@dutchcoders.io>, 2016 */
 //!
+#![allow(bad_style)]
 
 #[macro_use]
 extern crate bitflags;
@@ -10,30 +11,43 @@ extern crate libc;
 pub mod keystone_const;
 
 use keystone_const::{Arch, Error, Mode, OptionType, OptionValue};
-use std::ffi::CStr;
-use std::fmt;
-use std::os::raw::c_char;
+use ::std::{
+    ffi::CStr,
+    fmt,
+    ptr,
+};
+use ::libc::{
+    c_char,
+    c_uchar,
+    c_int,
+    c_uint,
+    size_t,
+};
 
-#[allow(non_camel_case_types)]
-pub type ks_handle = libc::size_t;
+/// Opaque type representing the Keystone engine
+#[repr(C)]
+pub struct ks_engine {
+    _private: [u8; 0],
+}
+pub type ks_handle = ptr::NonNull<ks_engine>;
 
 extern "C" {
-    pub fn ks_version(major: *mut u32, minor: *mut u32) -> u32;
-    pub fn ks_arch_supported(arch: Arch) -> bool;
-    pub fn ks_open(arch: Arch, mode: Mode, engine: *mut ks_handle) -> Error;
+    pub fn ks_version(major: *mut c_uint, minor: *mut c_uint) -> c_uint;
+    pub fn ks_arch_supported(arch: Arch) -> c_int;
+    pub fn ks_open(arch: Arch, mode: Mode, engine: *mut Option<ks_handle>) -> Error;
     pub fn ks_asm(
         engine: ks_handle,
         string: *const c_char,
         address: u64,
-        encoding: *mut *mut libc::c_uchar,
-        encoding_size: *mut libc::size_t,
-        stat_count: *mut libc::size_t,
-    ) -> u32;
+        encoding: *mut *mut c_uchar,
+        encoding_size: *mut size_t,
+        stat_count: *mut size_t,
+    ) -> c_int;
     pub fn ks_errno(engine: ks_handle) -> Error;
     pub fn ks_strerror(error_code: Error) -> *const c_char;
     pub fn ks_option(engine: ks_handle, opt_type: OptionType, value: OptionValue) -> Error;
     pub fn ks_close(engine: ks_handle);
-    pub fn ks_free(encoding: *mut libc::c_uchar);
+    pub fn ks_free(encoding: *mut c_uchar);
 }
 
 impl Error {


### PR DESCRIPTION
  - A bool coming from C cannot be trusted; functionally it is a c_int,
    and conversion to bool must be done by comparing to 0;

  - similarly, a `#[repr(C)]` enum cannot be trusted to be a `u32`;
    it is more often than not a `c_int`. This could cause breakage with
    the ABI of the C functions of the binding. So the signatures and
    enum definitions have been adapted based on the
    `include/keystone/keystone.h` definitions.

  - and most importantly: a ks_handle is a `ks_engine *` in C parlance,
    and using `size_t` to represent it is not the right way. Moreover,
    so doing prevents the `Sync` and `Send` traits from being
    auto-unimplemented, meaning that this is implicitly asserting that
    keystone is multithread-safe, even for the same instance. If that is
    the case, then a `unsafe impl Sync for Keystone {}` (ditto for
    `Send`) should be added to make such assertion explicit.

    That's why an opaque type using the classic Rust idiom of a
    zero_sized #[repr(C)] struct has been made (while waiting for Rust
    to feature external types), and `Option<ptr::NonNull<_>>` is being
    used as the pointer type (equivalent to *mut _), but it allows to
    communicate nullable / non-nullable invariants at the type-level.
    This has then been transposed to the internals of keystone-rs.

___

Fixes my comment about multithreading in #418