### PR TITLE
Update the Python binding's Debian packaging to build for Python 3

### DIFF
--- a/bindings/python/debian/control
+++ b/bindings/python/debian/control
@@ -2,12 +2,18 @@ Source: keystone-engine
 Maintainer: Michael Mohr <akihana@gmail.com>
 Section: python
 Priority: optional
-Build-Depends: dh-python, python-all (>= 2.6.6-3), debhelper (>= 9)
+Build-Depends: dh-python, python-all (>= 2.6.6-3), debhelper (>= 9),
+ python-setuptools, python3-all, python3-setuptools
 Standards-Version: 3.9.6
+X-Python3-Version: >= 3.4
 Homepage: http://www.keystone-engine.org
 
 Package: python-keystone-engine
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}, keystone-engine1
-Description: Keystone assembler engine
+Description: Keystone assembler engine (Python 2)
 
+Package: python3-keystone-engine
+Architecture: all
+Depends: ${misc:Depends}, ${python3:Depends}, keystone-engine1
+Description: Keystone assembler engine (Python 3)

--- a/bindings/python/debian/rules
+++ b/bindings/python/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=keystone-engine
+
 %:
-	dh $@ --with python2 --buildsystem=pybuild
+	dh $@ --with python2,python3 --buildsystem=pybuild
 

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -715,9 +715,10 @@ size_t AsmParser::Run(bool NoInitialTextSection, uint64_t Address, bool NoFinali
     }
 
     //printf(">> 222 error = %u\n", Info.KsError);
-    if (!KsError)
+    if (!KsError) {
         KsError = Info.KsError;
         return 0;
+    }
 
     // We had an error, validate that one was emitted and recover by skipping to
     // the next line.


### PR DESCRIPTION
This PR updates the Debian packaging so that it also builds a Python 3 deb.  It also addresses what appears to be a bug in the ASM parser which was identified by GCC.