### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -5,6 +5,11 @@ To compile Keystone on Windows, see [COMPILE-WINDOWS.md](COMPILE-WINDOWS.md)
 
 To cross-compiling for Windows from Linux, see [COMPILE-WINDOWS-CROSS.md](COMPILE-WINDOWS-CROSS.md)
 
+Alternatively, you can build and install Keystone using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager with a single command:
+ - vcpkg install keystone
+
+VCPGK supports to build Keystone on Windows, Linux and Macos, the Keystone port in vcpkg is kept up to date by Microsoft team members and community contributors.
+
 Learn more on how to code your own tools with our samples.
 
  - For C sample code, see code in directory samples/


### PR DESCRIPTION
Keystone is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build Keystone, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for Keystone and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
