### PR TITLE
Debian Packaging: Let debuild support parallel building

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@
 
 
 %:
-	dh $@
+	dh $@ --parallel
 
 
 # dh_make generated override targets


### PR DESCRIPTION
This change provides parallel building for debian-family packaging
if someone wants to stay single job building(`-j1`), they are also able to use `export DEB_BUILD_OPTIONS="parallel=1"` command to stay on.