### PR TITLE
Fixes python binding installation on 64bit systems and systems with python3 as 'python' binary.

### DIFF
--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -16,9 +16,9 @@ install:
 	rm -rf prebuilt/win64/keystone.dll
 	rm -rf prebuilt/win32/keystone.dll
 	if test -n "${DESTDIR}"; then \
-		python setup.py build -b $(OBJDIR) install --root="${DESTDIR}"; \
+		python2 setup.py build -b $(OBJDIR) install --root="${DESTDIR}"; \
 	else \
-		python setup.py build -b $(OBJDIR) install; \
+		python2 setup.py build -b $(OBJDIR) install; \
 	fi
 
 install3:
@@ -38,7 +38,7 @@ sdist:
 	rm -rf prebuilt/win32/keystone.dll
 	cp README.pypi-src README
 	cp PKG-INFO.src PKG-INFO
-	python setup.py sdist register upload
+	python2 setup.py sdist register upload
 
 # build & upload PyPi package with source code of the core
 sdist3:
@@ -55,7 +55,7 @@ sdist_win:
 	rm -rf src/ dist/
 	cp README.pypi-win README
 	cp PKG-INFO.win PKG-INFO
-	python setup.py sdist register upload
+	python2 setup.py sdist register upload
 
 # build & upload PyPi package with prebuilt core
 # NOTE: be sure to have precompiled core under prebuilt/win*/ beforehand

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -145,7 +145,9 @@ class custom_build_clib(build_clib):
                     base_dir = os.path.realpath(os.curdir)
                     if SYSTEM == "darwin":
                         SETUP_DATA_FILES.append(base_dir + "/llvm/lib/libkeystone.dylib")
-                    else:  # Non-OSX
+                    elif os.path.isfile(base_dir+"/llvm/lib64/libkeystone.so"):  # non-osx 64bit
+                        SETUP_DATA_FILES.append(base_dir + "/llvm/lib64/libkeystone.so")
+                    else: # non-osx 32bit
                         SETUP_DATA_FILES.append(base_dir + "/llvm/lib/libkeystone.so")
 
                 # back to root dir


### PR DESCRIPTION
Fixes the location of the keystone.so file on 64bit Linux systems metioned in #457 for the build  and installation of the python bindings.
Additionally fixes an installation problem that occurs on systems with python3 as their standard python binary.