### PR TITLE
Travis-CI build & nmake batch file updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,51 @@ os:
   - osx
 
 matrix:
+  fast_finish: true
   include:
     - if: branch = master
       os: osx
+      osx_image: xcode10.1
       compiler: clang
+      before_cache:
+        - brew cleanup
+        - find /usr/local/Homebrew \! -regex ".+\.git.+" -delete;
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
+      before_install:
+        - cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core && git stash && git clean -d -f
       script: brew update && brew install --HEAD keystone
+
     - if: branch = master
       os: osx
+      osx_image: xcode10.1
       compiler: gcc
+      before_cache:
+        - brew cleanup
+        - find /usr/local/Homebrew \! -regex ".+\.git.+" -delete;
+      cache:
+        directories:
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
+      before_install:
+        - cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core && git stash && git clean -d -f
       script: brew update && brew install --HEAD keystone
+
+    - name: "Windows nmake 32bit"
+      os: windows
+      language: shell
+      script:
+        - mkdir build
+        - cd build
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86 '&' cmd.exe //C '..\nmake-dll.bat' X86 '&' cmd.exe //c '..\nmake-lib.bat' X86
+
+    - name: "Windows nmake 64bit"
+      os: windows
+      language: shell
+      script:
+        - mkdir build
+        - cd build
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&' cmd.exe //C '..\nmake-dll.bat' '&' cmd.exe //c '..\nmake-lib.bat'
+

--- a/nmake-dll-x86.bat
+++ b/nmake-dll-x86.bat
@@ -1,7 +1,0 @@
-:: Keystone assembler engine (www.keystone-engine.org)
-:: Build Keystone DLL (keystone.dll) for X86, on Windows with CMake & Nmake
-:: By Nguyen Anh Quynh, 2017
-
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD="X86" -G "NMake Makefiles" ..
-nmake
-

--- a/nmake-dll.bat
+++ b/nmake-dll.bat
@@ -3,7 +3,41 @@
 :: By Nguyen Anh Quynh, 2016
 
 :: This generates .\llvm\bin\keystone.dll
+:: Usage: nmake-dll.bat [x86 arm aarch64 m68k mips sparc], default build all.
 
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD="all" -G "NMake Makefiles" ..
+@echo off
+
+set flags="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON"
+
+set allparams=
+
+:loop
+set str=%1
+if "%str%"=="" (
+    goto end
+)
+set allparams=%allparams% %str%
+shift /0
+goto loop
+
+:end
+if "%allparams%"=="" (
+    goto eof
+)
+:: remove left, right blank
+:intercept_left
+if "%allparams:~0,1%"==" " set "allparams=%allparams:~1%" & goto intercept_left
+
+:intercept_right
+if "%allparams:~-1%"==" " set "allparams=%allparams:~0,-1%" & goto intercept_right
+
+:eof
+
+if "%allparams%"=="" (
+cmake "%flags%" -DLLVM_TARGETS_TO_BUILD="all" -G "NMake Makefiles" ..
+) else (
+cmake "%flags%" "-DLLVM_TARGETS_TO_BUILD=%allparams%" -G "NMake Makefiles" ..
+)
+
 nmake
 

--- a/nmake-lib.bat
+++ b/nmake-lib.bat
@@ -3,7 +3,41 @@
 :: By Nguyen Anh Quynh, 2016
 
 :: This generates .\llvm\lib\keystone.lib
+:: Usage: nmake-dll.bat [x86 arm aarch64 m68k mips sparc], default build all.
 
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DLLVM_TARGETS_TO_BUILD="all" -G "NMake Makefiles" ..
+@echo off
+
+set flags="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF"
+
+set allparams=
+
+:loop
+set str=%1
+if "%str%"=="" (
+    goto end
+)
+set allparams=%allparams% %str%
+shift /0
+goto loop
+
+:end
+if "%allparams%"=="" (
+    goto eof
+)
+:: remove left, right blank
+:intercept_left
+if "%allparams:~0,1%"==" " set "allparams=%allparams:~1%" & goto intercept_left
+
+:intercept_right
+if "%allparams:~-1%"==" " set "allparams=%allparams:~0,-1%" & goto intercept_right
+
+:eof
+
+if "%allparams%"=="" (
+cmake "%flags%" -DLLVM_TARGETS_TO_BUILD="all" -G "NMake Makefiles" ..
+) else (
+cmake "%flags%" "-DLLVM_TARGETS_TO_BUILD=%allparams%" -G "NMake Makefiles" ..
+)
+
 nmake
 


### PR DESCRIPTION
- changed nmake-dll.bat and nmake-lib.bat to handle arch options. 

- Travis-CI builds include Win32 and WIn64 nmake.

- Added caching for brew builds to speed up builds.