### PR TITLE
bindings/python: attempt to load versioned library

### DIFF
--- a/bindings/python/keystone/keystone.py
+++ b/bindings/python/keystone/keystone.py
@@ -18,7 +18,7 @@ if not hasattr(sys.modules[__name__], '__file__'):
     __file__ = inspect.getfile(inspect.currentframe())
 
 _lib_path = split(__file__)[0]
-_all_libs = ('keystone.dll', 'libkeystone.so', 'libkeystone.dylib')
+_all_libs = ('keystone.dll', 'libkeystone.so', 'libkeystone.so.' % KS_API_MAJOR, 'libkeystone.dylib')
 _found = False
 
 for _lib in _all_libs:


### PR DESCRIPTION
Some platforms split *.so into -devel, which then requires the python library to be patched to load libkeystone.so.0 instead of libkeystone.so.

Welcome for input to better solve this issue.