### PR TITLE
Remove import of keystone in setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -19,8 +19,7 @@ from distutils.command.sdist import sdist as _sdist
 from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
 from setuptools.command.develop import develop as _develop
 
-from keystone import __version__ as ksversion
-VERSION = ksversion
+VERSION = '0.9.2'
 SYSTEM = sys.platform
 IS_64BITS = platform.architecture()[0] == '64bit'
 


### PR DESCRIPTION
Otherwise `python setup.py build` can't work when keystone is not installed.