### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(KEYSTONE_VERSION_MAJOR 0)
 set(KEYSTONE_VERSION_MINOR 9)
 
 option(KEYSTONE_BUILD_STATIC_RUNTIME "Embed static runtime" ON)
+option(BUILD_LIBS_ONLY "Only build keystone library" 0)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
@@ -73,7 +74,7 @@ add_subdirectory(llvm)
 # for Windows, do not build kstool if buiding DLL
 # TODO: fix this
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-if (NOT BUILD_SHARED_LIBS)
+if (NOT BUILD_LIBS_ONLY AND NOT BUILD_SHARED_LIBS)
     add_subdirectory(kstool)
 endif()
 else()
@@ -112,7 +113,11 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeUninstall.cmake"
     IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CMakeUninstall.cmake)
+if(NOT BUILD_LIBS_ONLY)
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CMakeUninstall.cmake)
+endif()
 
-add_subdirectory(suite/fuzz)
+if(NOT BUILD_LIBS_ONLY)
+    add_subdirectory(suite/fuzz)
+endif()

--- a/include/keystone/keystone.h
+++ b/include/keystone/keystone.h
@@ -16,11 +16,19 @@ extern "C" {
 #ifdef _MSC_VER     // MSVC compiler
 #pragma warning(disable:4201)
 #pragma warning(disable:4100)
+#ifndef KEYSTONE_STATIC
 #define KEYSTONE_EXPORT __declspec(dllexport)
+#else
+#define KEYSTONE_EXPORT
+#endif
 #else
 #ifdef __GNUC__
 #include <stdbool.h>
+#ifndef KEYSTONE_STATIC
 #define KEYSTONE_EXPORT __attribute__((visibility("default")))
+#else
+#define KEYSTONE_EXPORT
+#endif
 #else
 #define KEYSTONE_EXPORT
 #endif

--- a/llvm/keystone/CMakeLists.txt
+++ b/llvm/keystone/CMakeLists.txt
@@ -53,6 +53,14 @@ set_target_properties(
   SOVERSION ${KEYSTONE_VERSION_MAJOR}
 )
 
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(
+    keystone
+    PUBLIC
+    KEYSTONE_STATIC
+  )
+endif()
+
 if (APPLE)
   set_target_properties(keystone
                         PROPERTIES


### PR DESCRIPTION
With these improvements you are now able to include keystone in your CMake project with `add_subdirectory` and not have all the fuzzers and uninstall.

It also fixes an issue where things are marked as `__declspec(dllexport)`, even when keystone is built as a static library. This is backwards compatible and will behave as it currently behaves if you don't define `KEYSTONE_STATIC`.