### PR TITLE
rust: force CMake to use lib as libdir on systems that would normally…

### DIFF
--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -22,6 +22,7 @@ fn build_with_cmake() {
     }
 
     let dest = cmake::Config::new("keystone")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .define("BUILD_LIBS_ONLY", "1")
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("LLVM_TARGETS_TO_BUILD", "all")


### PR DESCRIPTION
The `CMakeLists.txt` script used by Keystone relies on GNUInstallDirs to determine the libdir when building CMake, which would result in `lib` for Debian-based distributions, but `lib64` for pretty much everything else. This means that when using the Rust bindings, `rustc` wouldn't be able to locate the static library on those distributions. This simply fixes `build.rs` to set `CMAKE_INSTALL_LIBDIR` to `lib`, such that it always builds `libkeystone.a` in `lib`, such that `rustc` always know where to find the static library when linking.