### PR TITLE
Make C# binding cross-plat through better NuGet packaging

### DIFF
--- a/bindings/csharp/Keystone.Net/.nuget/Keystone.Net.targets
+++ b/bindings/csharp/Keystone.Net/.nuget/Keystone.Net.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeLibs Include="$(MSBuildThisFileDirectory)win-x64\*.dll"
+      Condition="($([MSBuild]::IsOsPlatform('Windows')) And ('$(Platform)' == 'x64' Or '$(Platform)' == 'AnyCPU') And '$(RuntimeIdentifier)' == '') Or '$(RuntimeIdentifier)' == 'win-x64'" />
+    <NativeLibs Include="$(MSBuildThisFileDirectory)win-x86\*.dll"
+      Condition="($([MSBuild]::IsOsPlatform('Windows')) And '$(Platform)' == 'x86' And '$(RuntimeIdentifier)' == '') Or '$(RuntimeIdentifier)' == 'win-x86'" />
+    <NativeLibs Include="$(MSBuildThisFileDirectory)linux-x64\*.so"
+      Condition="($([MSBuild]::IsOsPlatform('Linux')) And '$(RuntimeIdentifier)' == '') Or '$(RuntimeIdentifier)' == 'linux-x64'" />
+    <NativeLibs Include="$(MSBuildThisFileDirectory)osx-x64\*.dylib"
+      Condition="($([MSBuild]::IsOsPlatform('OSX')) And '$(RuntimeIdentifier' == '') Or '$(RuntimeIdentifier)' == 'osx-x64'" />
+    <None Include="@(NativeLibs)">
+      <Link>%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Targeting .NET Standard implies a desire to be cross-plat, so I've created a targets file that can be placed in a NuGet package alongside compiled keystone dynamic libraries for win-x64, win-x86, linux-x64, and osx-x64. Doing this makes it so that the projects consuming the NuGet package can be run on any of those operating systems with `dotnet build` and `dotnet run` and projects can be built for any other system with `dotnet publish --os TARGET_OS`.

Working example of this package consumed in [this repo](https://github.com/jonko0493/Wiinject) and can be downloaded from an Azure DevOps feed [here](https://dev.azure.com/jonko0493/haroohie-public/_packaging?_a=package&feed=wiinject&view=overview&package=Keystone.Net&version=0.9.4&protocolType=NuGet).