### PR TITLE
Haskell bindings: fix sdist generation/pkg install

### DIFF
--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -1,6 +1,5 @@
-This documentation explains how to install the Keystone Haskell bindings from
-source.
-
+# Keystone Haskell bindings
+## Building
 1. Install the core Keystone Assembler as a dependency:
 
    Follow docs/COMPILE.md in the root directory to compile & install the core.
@@ -24,4 +23,29 @@ To build a sample (after having built and installed the Haskell bindings):
 ```
 $ cd bindings/haskell
 $ ghc --make samples/Sample.hs
+```
+
+## Using as a dependency
+### In a Cabal project
+Add the following to the `cabal.project` file in the project root:
+
+```text
+source-repository-package
+  type: git
+  location: https://github.com/keystone-engine/keystone
+  subdir:
+    bindings/haskell
+  tag: master
+
+-- if the file didn't already exist, add the following also
+packages: .
+```
+
+### In a Stack project
+Add the following to the `stack.yaml` file in the project root:
+
+```yaml
+extra-deps:
+- git: https://github.com/keystone-engine/keystone
+  subdir: bindings/haskell
 ```

--- a/bindings/haskell/keystone.cabal
+++ b/bindings/haskell/keystone.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                keystone
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            Keystone lightweight multi-platform, multi-architecture assembler framework
 description:         Haskell bindings for the Keystone assembler
 homepage:            https://github.com/keystone-engine/keystone
@@ -11,6 +11,8 @@ author:              Adrian Herrera
 category:            System
 build-type:          Simple
 cabal-version:       >= 1.10
+
+extra-source-files:  src/include/*.h
 
 library
   exposed-modules:     Keystone.Internal.Core


### PR DESCRIPTION
Cabal adds C source files to the sdist automatically, but not the
contents of header dirs. That must be done explicitly. With this
change,`cabal sdist` will produce a buildable sdist (previously, it
would fail due to missing a header file).