### PR TITLE
properly initialize radix

### DIFF
--- a/llvm/keystone/ks.cpp
+++ b/llvm/keystone/ks.cpp
@@ -522,7 +522,6 @@ ks_err ks_close(ks_engine *ks)
 KEYSTONE_EXPORT
 ks_err ks_option(ks_engine *ks, ks_opt_type type, size_t value)
 {
-    ks->MAI->setRadix(16);
     switch(type) {
         case KS_OPT_SYNTAX:
             if (ks->arch != KS_ARCH_X86)

--- a/llvm/lib/MC/MCAsmInfo.cpp
+++ b/llvm/lib/MC/MCAsmInfo.cpp
@@ -49,6 +49,7 @@ MCAsmInfo::MCAsmInfo() {
   Code32Directive = ".code32";
   Code64Directive = ".code64";
   AssemblerDialect = 0;
+  Radix = 10;
   AllowAtInName = false;
   SupportsQuotedNames = true;
   UseDataRegionDirectives = false;


### PR DESCRIPTION
[AsmLexer.cpp#L28](https://github.com/keystone-engine/keystone/blob/master/llvm/lib/MC/MCParser/AsmLexer.cpp#L28)
```cpp
AsmLexer::AsmLexer(const MCAsmInfo &MAI) : MAI(MAI) {
  CurPtr = nullptr;
  isAtStartOfLine = true;
  AllowAtInIdentifier = !StringRef(MAI.getCommentString()).startswith("@");
  defaultRadix = MAI.getRadix(); // <----
}
```


The `dafaultRadix` field is set to `MAI.getRadix()`, and `MAI.Radix` may not be set at the time `MAI.getRadix()` is called.
PR #382 attempted to fix this issue by adding `ks->MAI->setRadix(16)` to `ks_option()`, but `ks_option()` may not be called when assembling the instructions, for example, on keystone's [offcial tutorial](https://www.keystone-engine.org/docs/tutorial.html)
```python
ks = Ks(KS_ARCH_X86, KS_MODE_32)
encoding, count = ks.asm(CODE)
```


In this case `MAI.Radix` is still not initialized, so `defaultRadix` can be any value. When `defaultRadix` is anything other than 16, then `[1-9][0-9]*` in instructions will be assembled as decimal values ([AsmLexer.cpp#L262](https://github.com/keystone-engine/keystone/blob/master/llvm/lib/MC/MCParser/AsmLexer.cpp#L262)), otherwise when `defaultRadix` is 16, `[1-9][0-9]*` in instructions will be assembled as hex values ([AsmLexer.cpp#L264](https://github.com/keystone-engine/keystone/blob/master/llvm/lib/MC/MCParser/AsmLexer.cpp#L264)). As a result, the behavior will be unpredictable.

---
I think the default radix should be 10 because otherwise we won't be able to assemble instructions with decimal values, If users wish to change the default radix to 16, they can use `KS_OPT_SYNTAX_RADIX16` option.
[AsmLexer.cpp#L265](https://github.com/keystone-engine/keystone/blob/master/llvm/lib/MC/MCParser/AsmLexer.cpp#L265)
```cpp
AsmToken AsmLexer::LexDigit()
{
  // Decimal integer: [1-9][0-9]*
  if (CurPtr[-1] != '0' || CurPtr[0] == '.') {
    unsigned Radix = doLookAhead(CurPtr, 10);

    if (defaultRadix == 16)
      Radix = 16;
......
```