### PR TITLE
use full prototypes for functions without parameters

### DIFF
--- a/bindings/ruby/keystone_gem/ext/keystone.c
+++ b/bindings/ruby/keystone_gem/ext/keystone.c
@@ -27,7 +27,7 @@ VALUE KsClass = Qnil;
 VALUE KsError = Qnil;
 
 
-void Init_keystone() {
+void Init_keystone(void) {
     rb_require("keystone/keystone_const");
     KeystoneModule = rb_define_module("Keystone");
     KsError = rb_define_class_under(KeystoneModule, "KsError", rb_eStandardError);

--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -35,7 +35,7 @@ function(check_type_exists type files variable)
   add_cxx_include(includes "${files}")
   CHECK_CXX_SOURCE_COMPILES("
     ${includes} ${type} typeVar;
-    int main() {
+    int main(void) {
         return 0;
     }
     " ${variable})
@@ -83,7 +83,7 @@ check_include_file(histedit.h HAVE_HISTEDIT_H)
 check_cxx_source_compiles("
 #include <stddef.h>
 #include <cxxabi.h>
-int main() { return 0; }
+int main(void) { return 0; }
 " HAVE_CXXABI_H)
 
 # library checks
@@ -414,7 +414,7 @@ if( PURE_WINDOWS )
     #include <imagehlp.h>
     extern \"C\" void foo(PENUMLOADED_MODULES_CALLBACK);
     extern \"C\" void foo(BOOL(CALLBACK*)(PCSTR,ULONG_PTR,ULONG,PVOID));
-    int main(){return 0;}"
+    int main(void){return 0;}"
     HAVE_ELMCB_PCSTR)
   if( HAVE_ELMCB_PCSTR )
     set(WIN32_ELMCB_PCSTR "PCSTR")

--- a/llvm/cmake/config.guess
+++ b/llvm/cmake/config.guess
@@ -539,7 +539,7 @@ EOF
 		sed 's/^		//' << EOF >$dummy.c
 		#include <sys/systemcfg.h>
 
-		main()
+		int main(void)
 			{
 			if (!__power_pc())
 				exit(1);
@@ -622,7 +622,7 @@ EOF
 		#include <stdlib.h>
 		#include <unistd.h>
 
-		int main ()
+		int main (void)
 		{
 		#if defined(_SC_KERNEL_BITS)
 		    long bits = sysconf(_SC_KERNEL_BITS);
@@ -684,8 +684,8 @@ EOF
 	eval $set_cc_for_build
 	sed 's/^	//' << EOF >$dummy.c
 	#include <unistd.h>
-	int
-	main ()
+
+	int main (void)
 	{
 	  long cpu = sysconf (_SC_CPU_VERSION);
 	  /* The order matters, because CPU_IS_HP_MC68K erroneously returns
@@ -1338,7 +1338,7 @@ cat >$dummy.c <<EOF
 # include <sys/types.h>
 # include <sys/utsname.h>
 #endif
-main ()
+int main (void)
 {
 #if defined (sony)
 #if defined (MIPSEB)

--- a/llvm/cmake/modules/CheckAtomic.cmake
+++ b/llvm/cmake/modules/CheckAtomic.cmake
@@ -11,7 +11,7 @@ function(check_working_cxx_atomics varname)
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
 std::atomic<int> x;
-int main() {
+int main(void) {
   return x;
 }
 " ${varname})
@@ -46,7 +46,7 @@ CHECK_CXX_SOURCE_COMPILES("
 #include <Intrin.h> /* Workaround for PR19898. */
 #include <windows.h>
 #endif
-int main() {
+int main(void) {
 #ifdef _MSC_VER
         volatile LONG val = 1;
         MemoryBarrier();

--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -37,7 +37,7 @@ if(NOT LLVM_FORCE_USE_OLD_TOOLCHAIN)
       check_cxx_source_compiles("
 #include <atomic>
 std::atomic<float> x(0.0f);
-int main() { return (float)x; }"
+int main(void) { return (float)x; }"
         LLVM_NO_OLD_LIBSTDCXX)
       if(NOT LLVM_NO_OLD_LIBSTDCXX)
         message(FATAL_ERROR "Host Clang must be able to find libstdc++4.7 or newer!")
@@ -457,7 +457,7 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11 -Werror=non-virtual-dtor")
       CHECK_CXX_SOURCE_COMPILES("class base {public: virtual void anchor();protected: ~base();};
                                  class derived final : public base { public: ~derived();};
-                                 int main() { return 0; }"
+                                 int main(void) { return 0; }"
                                 CXX_WONT_WARN_ON_FINAL_NONVIRTUALDTOR)
       set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
       append_if(CXX_WONT_WARN_ON_FINAL_NONVIRTUALDTOR
@@ -471,7 +471,7 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
     # line is also a // comment.
     set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror -Wcomment")
-    CHECK_C_SOURCE_COMPILES("// \\\\\\n//\\nint main() {return 0;}"
+    CHECK_C_SOURCE_COMPILES("// \\\\\\n//\\nint main(void) {return 0;}"
                             C_WCOMMENT_ALLOWS_LINE_WRAP)
     set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
     if (NOT C_WCOMMENT_ALLOWS_LINE_WRAP)
@@ -508,7 +508,7 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
                                #include <cassert>
                                #define NDEBUG
                                #include <cassert>
-                               int main() { assert(this code is not compiled); }"
+                               int main(void) { assert(this code is not compiled); }"
                                CXX_SUPPORTS_MODULES)
     set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
     if (CXX_SUPPORTS_MODULES)

--- a/samples/sample.c
+++ b/samples/sample.c
@@ -61,7 +61,7 @@ static bool sym_resolver(const char *symbol, uint64_t *value)
 }
 
 // test symbol resolver to handle missing symbols
-static int test_sym_resolver()
+static int test_sym_resolver(void)
 {
     ks_engine *ks;
     ks_err err;


### PR DESCRIPTION
This PR fixes some C syntax issues which are deprecated in modern C standards and will eventually lead to build failures with modern compiles like Clang. For details see:

 * https://wiki.gentoo.org/wiki/Modern_C_porting
 * https://bugs.gentoo.org/879665