### PR TITLE
Fix directive address update for non target-specific directives

### DIFF
--- a/suite/regress/all_archs_value_directive.py
+++ b/suite/regress/all_archs_value_directive.py
@@ -41,7 +41,7 @@ bl 0xc008;
         ks = Ks(KS_ARCH_PPC, KS_MODE_PPC32 + KS_MODE_BIG_ENDIAN)
         encoding, count = ks.asm(self.asm, 0xc0000000)
         expected_encoding = [56, 128, 0, 1, 56, 132, 0, 1, 72, 0, 191, 249, 56,
-                             128, 0, 1, 56, 165, 0, 1, 72, 0, 191, 249]
+                             128, 0, 1, 56, 165, 0, 1, 72, 0, 191, 245]
         self.assertEqual(encoding, expected_encoding)
 
 


### PR DESCRIPTION
The previous fix https://github.com/keystone-engine/keystone/pull/274 only updated the address for target specific directives. There are a number of generic directives that also emit bytes so the address needs to be updated.

The ppc regression test should have caught this but the expected value was incorrect.
The expected branch target for the PPC test is off by 8 and has been updated from
```
0x00000000   4                 38800001  li r4, 1
0x00000004   4                 38840001  addi r4, r4, 1
0x00000008   4                 4800bff9  bl 0xc000
0x0000000c   4                 38800001  li r4, 1
0x00000010   4                 38a50001  addi r5, r5, 1
0x00000014   4                 4800bff9  bl 0xc00c
```
to
```
0x00000000   4                 38800001  li r4, 1
0x00000004   4                 38840001  addi r4, r4, 1
0x00000008   4                 4800bff9  bl 0xc000
0x0000000c   4                 38800001  li r4, 1
0x00000010   4                 38a50001  addi r5, r5, 1
0x00000014   4                 4800bff5  bl 0xc008
```