### PR TITLE
Fixed LLVM_TARGETS_TO_BUILD in CMakeLists

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -182,7 +182,7 @@ set(LLVM_ALL_TARGETS
   )
 
 set(LLVM_TARGETS_TO_BUILD "all"
-    CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
+    CACHE STRING "Space-separated list of targets to build, or \"all\".")
 
 set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ""
   CACHE STRING "Semicolon-separated list of experimental targets to build.")
@@ -218,8 +218,12 @@ option(LLVM_ENABLE_THREADS "Use threads if available." ON)
 
 option(LLVM_ENABLE_ZLIB "Use zlib for compression/decompression if available." ON)
 
+message(STATUS "LLVM_TARGETS_TO_BUILD: ${LLVM_TARGETS_TO_BUILD}")
+
 if( LLVM_TARGETS_TO_BUILD STREQUAL "all" )
-  set( LLVM_TARGETS_TO_BUILD ${LLVM_ALL_TARGETS} )
+  set(LLVM_TARGETS_TO_BUILD ${LLVM_ALL_TARGETS})
+else()
+  separate_arguments(LLVM_TARGETS_TO_BUILD)
 endif()
 
 set(LLVM_TARGETS_TO_BUILD
@@ -373,6 +377,7 @@ if (LLVM_USE_OPROFILE)
 endif (LLVM_USE_OPROFILE)
 
 message(STATUS "Constructing LLVMBuild project information")
+message(STATUS "LLVM targets to build: ${LLVM_TARGETS_TO_BUILD}")
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} ${LLVMBUILDTOOL}
             --native-target "${LLVM_NATIVE_ARCH}"


### PR DESCRIPTION
Currently, it seems that it is not possible to compile Keystone by picking individual architectures
For example, when using an external project, none of these work:
```cmake
set(KEYSTONE_LLVM_TARGETS "AArch64;ARM;Mips;PowerPC;Sparc;SystemZ;X86")
set(KEYSTONE_CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=${KEYSTONE_LLVM_TARGETS})
ExternalProject_Add(keystone-engine SOURCE_DIR ${KEYSTONE_DIR} INSTALL_COMMAND "" CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS})
```
```cmake
set(KEYSTONE_CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;Mips;PowerPC;Sparc;SystemZ;X86")
ExternalProject_Add(keystone-engine SOURCE_DIR ${KEYSTONE_DIR} INSTALL_COMMAND "" CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS})
```
```cmake
set(KEYSTONE_CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=AArch64;ARM;Mips;PowerPC;Sparc;SystemZ;X86)
ExternalProject_Add(keystone-engine SOURCE_DIR ${KEYSTONE_DIR} INSTALL_COMMAND "" CMAKE_ARGS ${KEYSTONE_CMAKE_ARGS})
```
This PR fixes that by using space-separated targets in `LLVM_TARGETS_TO_BUILD`, and parsing with the CMake builtin command `separate_arguments`, available since at least CMake 3.0 (I didn't check earlier versions)