### PR TITLE
update Mips CPU to Mips r6

### DIFF
--- a/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
+++ b/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp
@@ -44,9 +44,9 @@ using namespace llvm_ks;
 StringRef MIPS_MC::selectMipsCPU(const Triple &TT, StringRef CPU) {
   if (CPU.empty() || CPU == "generic") {
     if (TT.getArch() == Triple::mips || TT.getArch() == Triple::mipsel)
-      CPU = "mips32";
+      CPU = "mips32r6";
     else
-      CPU = "mips64";
+      CPU = "mips64r6";
   }
   return CPU;
 }


### PR DESCRIPTION
The current MIPS CPU selections are "mips32" and "mips64." In this case, several instructions, such as "dext," are not supported. 
Therefore, it is necessary to upgrade the CPU in the code to "mips32r6" and "mips64r6" in order to support more instructions.


Such changes appear in LLVM in a similar form:
https://github.com/llvm/llvm-project/blob/78fa41524b6f6e2696ff21ec50e760311ac939a3/llvm/lib/Target/Mips/MCTargetDesc/MipsMCTargetDesc.cpp#L49