### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,0 +1,31 @@
+# Builds the codebase with cmake
+
+name: CMake CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  linux-build:
+    name: Linux
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y \
+              cmake \
+              gcc
+      - name: Configure
+        shell: bash
+        run: |
+          cmake -B build
+      - name: Bulid
+        shell: bash
+        run: |
+          cmake --build build

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,6 +1,9 @@
 name: PyPI 📦 Distribution
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/rust-build.yml
+++ b/.github/workflows/rust-build.yml
@@ -1,0 +1,31 @@
+# Builds the codebase with cmake on ubuntu, windows and macos.
+#
+name: Rust CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  linux-test:
+    name: Linux
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y \
+              cmake \
+              libclang-dev \
+              pkg-config \
+              gcc
+      - name: Build and test rust
+        shell: bash
+        run: |
+          cd bindings/rust
+          cargo test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Keystone Assembler Engine (www.keystone-engine.org)
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10.0)
 project(keystone)
 
 set(KEYSTONE_VERSION_MAJOR 0)
@@ -13,23 +13,6 @@ option(BUILD_LIBS_ONLY "Only build keystone library" 0)
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-if (POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
-endif()
-
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
-endif()
-
-if (POLICY CMP0063)
-  set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # automatic when 3.3.2 is required
 endif()
 
 if (CMAKE_VERSION VERSION_LESS 3.1.20141117)

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "keystone"
 version = "0.9.2"
+edition = "2018"
 authors = [
   "Remco Verhoef <remco.verhoef@dutchcoders.io>",
   "Tasuku SUENAGA a.k.a. gunyarakun <tasuku-s-github@titech.ac>"

--- a/bindings/rust/keystone-sys/Cargo.toml
+++ b/bindings/rust/keystone-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "keystone-sys"
 version = "0.9.2"
+edition = "2018"
 authors = [
   "Remco Verhoef <remco.verhoef@dutchcoders.io>",
   "Tasuku SUENAGA a.k.a. gunyarakun <tasuku-s-github@titech.ac>"

--- a/bindings/rust/keystone-sys/build.rs
+++ b/bindings/rust/keystone-sys/build.rs
@@ -17,7 +17,7 @@ fn build_with_cmake() {
         // This only happens when using the crate via a `git` reference as the
         // published version already embeds keystone's source.
         let pwd = std::env::current_dir().unwrap();
-        let keystone_dir = pwd.ancestors().skip(3).next().unwrap();
+        let keystone_dir = pwd.ancestors().nth(3).unwrap();
         symlink(keystone_dir, "keystone").expect("failed to symlink keystone");
     }
 

--- a/bindings/rust/keystone-sys/src/lib.rs
+++ b/bindings/rust/keystone-sys/src/lib.rs
@@ -10,19 +10,9 @@ extern crate libc;
 
 pub mod keystone_const;
 
+use ::libc::{c_char, c_int, c_uchar, c_uint, size_t};
+use ::std::{ffi::CStr, fmt, ptr};
 use keystone_const::{Arch, Error, Mode, OptionType, OptionValue};
-use ::std::{
-    ffi::CStr,
-    fmt,
-    ptr,
-};
-use ::libc::{
-    c_char,
-    c_uchar,
-    c_int,
-    c_uint,
-    size_t,
-};
 
 /// Opaque type representing the Keystone engine
 #[repr(C)]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -90,7 +90,7 @@ impl Keystone {
         let err = unsafe { ffi::ks_open(arch, mode, &mut handle) };
         if err == Error::OK {
             Ok(Keystone {
-                handle: handle.expect("Got NULL engine from ks_open()")
+                handle: handle.expect("Got NULL engine from ks_open()"),
             })
         } else {
             Err(err)

--- a/kstool/CMakeLists.txt
+++ b/kstool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Kstool for Keystone assembler engine.
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(kstool)
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,25 +1,12 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10.0)
 
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-if(POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
-endif()
-
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
 endif()
 
 if(CMAKE_VERSION VERSION_LESS 3.1.20141117)

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -21,6 +21,7 @@
 #include <algorithm> // for std::all_of
 #include <cassert>
 #include <cstddef> // for std::size_t
+#include <cstdint>
 #include <cstdlib> // for qsort
 #include <functional>
 #include <iterator>


### PR DESCRIPTION
This PR does the minimum wrt updating to "modern" build setups.

- update cmake builds to (successfully) build with modern cmake
- update c header includes to build with gcc15
- update rust bindings to be able to build
- update rust bindings pass clippy lints