### PR TITLE
Fix build compatibility with CMake 4, GCC 15, and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Keystone Assembler Engine (www.keystone-engine.org)
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10.0)
 project(keystone)
 
 set(KEYSTONE_VERSION_MAJOR 0)
@@ -13,23 +13,6 @@ option(BUILD_LIBS_ONLY "Only build keystone library" 0)
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-if (POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
-endif()
-
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
-endif()
-
-if (POLICY CMP0063)
-  set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # automatic when 3.3.2 is required
 endif()
 
 if (CMAKE_VERSION VERSION_LESS 3.1.20141117)

--- a/kstool/CMakeLists.txt
+++ b/kstool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Kstool for Keystone assembler engine.
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10.0)
 
 project(kstool)
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1,25 +1,12 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10.0)
 
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-if(POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
-endif()
-
-if (POLICY CMP0051)
-  # CMake 3.1 and higher include generator expressions of the form
-  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
-  # stripped everywhere that access the SOURCES property, so we just
-  # defer to the OLD behavior of not including generator expressions
-  # in the output for now.
-  cmake_policy(SET CMP0051 OLD)
 endif()
 
 if(CMAKE_VERSION VERSION_LESS 3.1.20141117)

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -21,6 +21,7 @@
 #include <algorithm> // for std::all_of
 #include <cassert>
 #include <cstddef> // for std::size_t
+#include <cstdint>
 #include <cstdlib> // for qsort
 #include <functional>
 #include <iterator>

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -92,7 +92,8 @@
 #define LLVM_LVALUE_FUNCTION
 #endif
 
-#if __has_feature(cxx_constexpr) || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if __has_feature(cxx_constexpr) || defined(__GXX_EXPERIMENTAL_CXX0X__) ||     \
+    defined(_MSC_VER)
 # define LLVM_CONSTEXPR constexpr
 #else
 # define LLVM_CONSTEXPR
@@ -310,7 +311,7 @@
 ///   int k;
 ///   long long l;
 /// };
-/// LLVM_PACKED_END 
+/// LLVM_PACKED_END
 #ifdef _MSC_VER
 # define LLVM_PACKED(d) __pragma(pack(push, 1)) d __pragma(pack(pop))
 # define LLVM_PACKED_START __pragma(pack(push, 1))


### PR DESCRIPTION
This PR applies several small patches to fix build failures across different compilers and build systems.

CMake 4 and GCC 15 fixes (taken unaltered from NixOS/nixpkgs#450265):
* Fixes build breakage introduced by CMake 4's stricter policy handling
* Fixes build breakage with GCC 15

MSVC fixes for the RISCV backend:
* `LLVM_CONSTEXPR` was not defined for MSVC since the existing checks `__has_feature(cxx_constexpr)` and `defined(__GXX_EXPERIMENTAL_CXX0X__)` are GCC/Clang-specific.

    Added a `defined(_MSC_VER)` check so that array_lengthof is correctly marked constexpr on MSVC, fixing a static_assert compile error in RISCVAsmBackend.h.

* RISCVGenRegisterInfo.inc was generated from a newer LLVM snapshot where `RegSize` and `Alignment` had already been removed from `MCRegisterClass` (upstream removal in rL339350, LLVM 7.0).

    Keystone's `MCRegisterClass` retains these fields from the LLVM 4.0 era, causing a member count mismatch and MSVC error C3852.

    Added the missing fields to each register class initializer to match keystone's struct layout. These values are never consulted by the assembler — spill slot calculations belong to the codegen layer which keystone does not include.