### PR TITLE
Fix Thumb2 conditinal branch

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMMCCodeEmitter.cpp
@@ -593,7 +593,7 @@ static uint32_t getBranchTargetOpValue(const MCInst &MI, unsigned OpIdx,
   const MCOperand &MO = MI.getOperand(OpIdx);
 
   // If the destination is an immediate, we have nothing to do.
-  if (MO.isImm()) return MO.getImm();
+  if (MO.isImm()) return (MO.getImm() - MI.getAddress() - 4);
   assert(MO.isExpr() && "Unexpected branch target type!");
   const MCExpr *Expr = MO.getExpr();
   MCFixupKind Kind = MCFixupKind(FixupKind);


### PR DESCRIPTION
kstool thumb "bne.w 0x680168E0" 0x68016578 
should generate '40 F0 B2 81' which is the same as the one 
from IDA-Pro "0x68016578: 40 F0 B2 81  BNE.W  loc_680168E0"
or 
capstone.Cs(CS_ARCH_ARM,CS_MODE_THUMB).disasm(the-generate-bytes,0x8016578) should match the raw-asm "bne.w 0x680168E0"

the bug code generate the wrong result: [ 56 f0 6e 84 ] which capstone can not disasm out the raw-asm